### PR TITLE
feat: theme fix to default & remove theme selector

### DIFF
--- a/apps/game-builder/package.json
+++ b/apps/game-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-builder",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/game-builder/src/components/button/GameSubmitButton.tsx
+++ b/apps/game-builder/src/components/button/GameSubmitButton.tsx
@@ -1,9 +1,7 @@
-import { useThemeStore } from "@/store/useTheme";
 import { RocketIcon } from "@radix-ui/react-icons";
 import ThemedIconButton from "@themed/ThemedIconButton";
 
-export default function GameSubmitButton() {
-  const { theme } = useThemeStore((state) => state);
+export default function GameSubmitButton({ theme }: { theme?: string }) {
   let themeClass;
 
   switch (theme) {

--- a/apps/game-builder/src/components/card/choice/DotIndicator.tsx
+++ b/apps/game-builder/src/components/card/choice/DotIndicator.tsx
@@ -1,8 +1,10 @@
-"use client";
-import { useThemeStore } from "@/store/useTheme";
-
-export default function DotIndicator({ isChoosen }: { isChoosen: boolean }) {
-  const { theme } = useThemeStore((state) => state);
+export default function DotIndicator({
+  isChoosen,
+  theme,
+}: {
+  isChoosen: boolean;
+  theme?: string;
+}) {
   const unChoosenClass =
     theme === "old-game" ? "!w-5 !h-5 -left-[16px]" : "!w-4 !h-4 -left-[8px]";
   const choosenClass =

--- a/apps/game-builder/src/components/card/page/DotIndicator.tsx
+++ b/apps/game-builder/src/components/card/page/DotIndicator.tsx
@@ -1,9 +1,4 @@
-"use client";
-import { useThemeStore } from "@/store/useTheme";
-
-export default function DotIndicator() {
-  const { theme } = useThemeStore((state) => state);
-
+export default function DotIndicator({ theme }: { theme?: string }) {
   return (
     <div
       className={`absolute w-3 h-3 bg-green-500 rounded-full top-1/2 -translate-y-1/2 -left-2 -translate-x-[22px] ${theme === "old-game" ? "-translate-x-[25px]" : ""}`}

--- a/apps/game-builder/src/components/common/partial/TopNav.tsx
+++ b/apps/game-builder/src/components/common/partial/TopNav.tsx
@@ -1,20 +1,15 @@
 "use client";
 import BackButton from "@/components/button/BackButton";
-import ThemeSelector from "@/components/theme/ThemeSelector";
-import { useThemeStore } from "@/store/useTheme";
 
 export default function TopNav({ title }: { title: string }) {
-  const { theme } = useThemeStore((state) => state);
-
   return (
     <div
-      className={`w-full h-12 px-6 flex justify-between items-center sticky top-0 bg-[rgba(255,255,255,0.75)] backdrop-blur-lg transition-all z-[15] ${theme === "windows-98" ? "!bg-[rgba(175,175,175,0.75)] backdrop-blur-md" : ""}`}
+      className={`w-full h-12 px-6 flex justify-between items-center sticky top-0 bg-[rgba(255,255,255,0.75)] backdrop-blur-lg transition-all z-[15]`}
     >
       <BackButton />
       <h4 className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
         {title}
       </h4>
-      <ThemeSelector />
     </div>
   );
 }

--- a/apps/game-builder/src/components/game/builder/GameBuilder.tsx
+++ b/apps/game-builder/src/components/game/builder/GameBuilder.tsx
@@ -49,7 +49,7 @@ export default function GameBuilder() {
   return (
     <form onSubmit={onSubmit} className="relative flex h-full px-6 pt-4">
       <StoryLine />
-      <GameSubmitButton theme="" />
+      <GameSubmitButton />
 
       <div className="flex-1 flex flex-col gap-4">
         <GameBuilderContent

--- a/apps/game-builder/src/components/game/builder/GameBuilder.tsx
+++ b/apps/game-builder/src/components/game/builder/GameBuilder.tsx
@@ -49,7 +49,7 @@ export default function GameBuilder() {
   return (
     <form onSubmit={onSubmit} className="relative flex h-full px-6 pt-4">
       <StoryLine />
-      <GameSubmitButton />
+      <GameSubmitButton theme="" />
 
       <div className="flex-1 flex flex-col gap-4">
         <GameBuilderContent

--- a/apps/game-builder/src/components/game/edit/GameEditDraw.tsx
+++ b/apps/game-builder/src/components/game/edit/GameEditDraw.tsx
@@ -1,6 +1,5 @@
 "use client";
 import { useState } from "react";
-import { useThemeStore } from "@/store/useTheme";
 import {
   Drawer,
   DrawerClose,
@@ -14,12 +13,11 @@ import GameEditDrawTriggerButton from "./GameEditDrawTriggerButton";
 import ThemedButton from "@/components/theme/ui/ThemedButton";
 import GameEditFields from "@/components/game/edit/form/GameEditFields";
 
-export default function GameEditDraw() {
+export default function GameEditDraw({ theme }: { theme?: string }) {
   const [formData, setFormData] = useState({
     abridgement: "",
     description: "",
   });
-  const { theme } = useThemeStore((state) => state);
 
   const updateGameEdit = () => {
     console.log(formData);

--- a/apps/game-builder/src/components/game/edit/GameEditDrawTriggerButton.tsx
+++ b/apps/game-builder/src/components/game/edit/GameEditDrawTriggerButton.tsx
@@ -1,11 +1,11 @@
-"use client";
 import { Pencil2Icon } from "@radix-ui/react-icons";
 import { DrawerTrigger } from "@repo/ui/components/ui/Drawer.tsx";
-import { useThemeStore } from "@/store/useTheme";
 
-export default function GameEditDrawTriggerButton() {
-  const { theme } = useThemeStore((state) => state);
-
+export default function GameEditDrawTriggerButton({
+  theme,
+}: {
+  theme?: string;
+}) {
   return (
     <DrawerTrigger className="!absolute top-1 right-1 min-w-6 p-0 min-h-0 px-2 py-[2px]">
       {theme === "windows-98" ? "수정" : <Pencil2Icon className="h-4 w-4" />}


### PR DESCRIPTION
```
"name": "game-builder",
"version": "0.0.6",
```
- TopNav의 theme selector를 삭제했습니다.
  - 테마 설정 기능은, 이후에 game play에서 game의 theme 옵션에 따라 사용할 예정입니다. 
- `@component/theme` 외부에서 useThemeStore을 제거했습니다.
  - game-builder 구현 이후 시점에 폴더 째로 `/packages`의 `@repo/ui` 패키지로 이동해서 다른 모노레포에서 사용할 수 있도록 하려 합니다.
  - 모노레포에서 theme 전역 상태를 위한 스토어를 어떻게 사용할지 고민이 필요합니다.

```mermaid
graph LR;
id1(package/ui) ----> app/game-builder
id1(package/ui) --themed components--> app/game-play
app/game-play----> app/web
app/game-builder----> app/web
```