### PR TITLE
 feat(S1): 상단 네비게이션 기능 정리

### DIFF
--- a/apps/game-builder/package.json
+++ b/apps/game-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-builder",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/game-builder/src/app/builder/layout.tsx
+++ b/apps/game-builder/src/app/builder/layout.tsx
@@ -1,10 +1,16 @@
 import { ReactNode } from "react";
 import TopNav from "@/components/common/partial/TopNav";
+import { NextButton } from "@/components/button/NextButton";
 
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <>
-      <TopNav title="새 게임" />
+      <TopNav title="새 게임">
+        <NextButton
+          nextTo="/game/confirm"
+          options={{ seachParams: { id: true } }}
+        />
+      </TopNav>
       {children}
     </>
   );

--- a/apps/game-builder/src/app/confirm/layout.tsx
+++ b/apps/game-builder/src/app/confirm/layout.tsx
@@ -4,7 +4,7 @@ import TopNav from "@/components/common/partial/TopNav";
 export default function Layout({ children }: { children: ReactNode }) {
   return (
     <>
-      <TopNav title="새 게임" />
+      <TopNav title="새 게임" hasBackButton={true} />
       {children}
     </>
   );

--- a/apps/game-builder/src/components/button/NextButton.tsx
+++ b/apps/game-builder/src/components/button/NextButton.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { ArrowRightIcon } from "@radix-ui/react-icons";
+import { useRouter, useSearchParams } from "next/navigation";
+import ThemedIconButton from "@themed/ThemedIconButton";
+
+export function NextButton({
+  nextTo,
+  options,
+}: {
+  nextTo: string;
+  options?: { seachParams: { [key: string]: boolean } };
+}) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  let queryString = "";
+
+  for (const key in options?.seachParams) {
+    const match = searchParams.get(key);
+
+    if (match !== null) {
+      if (queryString === "") queryString = "?";
+      queryString += key + "=" + match;
+    }
+  }
+
+  return (
+    <ThemedIconButton
+      className="my-1"
+      onClick={() => router.push(nextTo + queryString)}
+    >
+      <ArrowRightIcon className="h-5 w-5 m-1" />
+    </ThemedIconButton>
+  );
+}

--- a/apps/game-builder/src/components/common/partial/TopNav.tsx
+++ b/apps/game-builder/src/components/common/partial/TopNav.tsx
@@ -1,15 +1,25 @@
 "use client";
 import BackButton from "@/components/button/BackButton";
+import { ReactNode } from "react";
 
-export default function TopNav({ title }: { title: string }) {
+export default function TopNav({
+  title,
+  hasBackButton = false,
+  children,
+}: {
+  title: string;
+  hasBackButton?: boolean;
+  children?: ReactNode;
+}) {
   return (
     <div
       className={`w-full h-12 px-6 flex justify-between items-center sticky top-0 bg-[rgba(255,255,255,0.75)] backdrop-blur-lg transition-all z-[15]`}
     >
-      <BackButton />
+      <div>{hasBackButton && <BackButton />}</div>
       <h4 className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2">
         {title}
       </h4>
+      <div>{children}</div>
     </div>
   );
 }


### PR DESCRIPTION
```
"name": "game-builder",
"version": "0.0.7",
```

### 상단 네비게이션 - 새 게임 생성 단계
새 게임 생성 단계에서 뒤로 가기와 앞으로 가기 버튼이 없는지 확인
![image](https://github.com/user-attachments/assets/5bd2c509-6dd0-4d89-8c55-f64e428249a9)

### 상단 네비게이션 - 게임 빌딩 단계
게임 빌딩 단계에서 뒤로 가기 버튼은 없고 앞으로 가기 버튼이 있는지 확인
![image](https://github.com/user-attachments/assets/4d08fa20-bf6d-43ad-9927-1307b1b34f04)


### 상단 네비게이션 - 게임 정보 확인
게임 정보 확인 단계에서 뒤로 가기 버튼은 있고 앞으로 가기 버튼이 없는지 확인
![image](https://github.com/user-attachments/assets/fc91247e-0ce5-4de1-bde1-012efde42148)
