### PR TITLE
feat(S1): 게임 빌딩 페이지 - 선택지 고정

### DIFF
--- a/apps/game-builder/src/actions/choice/getRecommendChoice.ts
+++ b/apps/game-builder/src/actions/choice/getRecommendChoice.ts
@@ -18,6 +18,15 @@ export const getRecommendChoice = async ({
   gameId: number;
   pageId: number;
 }): Promise<GetRecommendChoiceResponse> => {
+  const dummyResponse = {
+    title: "title 예상 응답",
+    description: "description 예상 응답",
+  };
+
+  return {
+    success: true,
+    choice: dummyResponse,
+  };
   try {
     const response = await fetch(
       `/game/${gameId}/page/${pageId}/recommend-choices`,

--- a/apps/game-builder/src/components/button/GameSubmitButton.tsx
+++ b/apps/game-builder/src/components/button/GameSubmitButton.tsx
@@ -1,5 +1,6 @@
 import { RocketIcon } from "@radix-ui/react-icons";
 import ThemedIconButton from "@themed/ThemedIconButton";
+import { useRouter } from "next/navigation";
 
 export default function GameSubmitButton({ theme }: { theme?: string }) {
   let themeClass;
@@ -11,11 +12,16 @@ export default function GameSubmitButton({ theme }: { theme?: string }) {
     default:
   }
 
+  const router = useRouter();
+  const goConfirm = async () => {
+    router.push("/game/confirm");
+  };
+
   return (
     <ThemedIconButton
       className={`!absolute left-2 bottom-2 !bg-green-500 rounded-sm z-[40] hover:animate-bounce`}
       themeClass={themeClass}
-      type="submit"
+      onClick={goConfirm}
     >
       <RocketIcon className="h-5 w-5 m-1" color="#eeeeee" />
     </ThemedIconButton>

--- a/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
+++ b/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
+import { useForm } from "react-hook-form";
 import { CheckIcon, Cross2Icon } from "@radix-ui/react-icons";
-import { Choice } from "@choosetale/nestia-type/lib/structures/Choice";
 import { CardContent, CardFooter } from "@repo/ui/components/ui/Card.tsx";
 import ThemedCard from "@themed/ThemedCard";
 import ThemedIconButton from "@themed/ThemedIconButton";
@@ -12,81 +12,79 @@ import DotIndicator from "./DotIndicator";
 import { StaticChoice } from "./StaticChoice";
 
 interface PageCardProps {
-  choice: Choice;
-  defaultCommitted: boolean;
-  commitChoice: (partialChoice: TempChoiceType) => void;
+  choice: TempChoiceType;
+  defaultFixed: boolean;
+  fixChoice: (partialChoice: TempChoiceType) => void;
   removeChoice: () => void;
 }
 
 export default function ChoiceCard({
   choice,
-  defaultCommitted,
-  commitChoice,
+  defaultFixed,
+  fixChoice,
   removeChoice,
 }: PageCardProps) {
-  const fakeDefultChoice = {
-    title: "테스트용 기본 값",
-    description: "테스트용 기본 설명",
-  } as any;
+  const [isFixed, setIsFixed] = useState(defaultFixed);
 
-  const [isCommitted, setIsCommitted] = useState(defaultCommitted);
-  const [formData, setFormData] = useState({
+  const defaultValues = {
     ...choice,
-    title: "",
-    description: "",
-  });
+    title: choice.title ?? "",
+    description: choice.description ?? "",
+  };
+  const {
+    register,
+    handleSubmit,
+    getValues,
+    formState: { errors },
+  } = useForm({ defaultValues });
 
-  const clickCommit = () => {
-    commitChoice(formData);
-    setIsCommitted(!isCommitted);
+  const onSubmit = (formData: typeof defaultValues) => {
+    fixChoice(formData);
+    setIsFixed(!isFixed);
   };
 
   const clickRemove = () => {
     removeChoice();
   };
 
+  if (isFixed) {
+    return <StaticChoice {...getValues()} removeChoice={clickRemove} />;
+  }
+
   return (
-    <ThemedCard className="relative min-h-24 !ml-12" isChoice={true}>
-      <DotIndicator isChoosen={isCommitted} />
+    <form onSubmit={handleSubmit(onSubmit)}>
+      <ThemedCard className="relative min-h-24 !ml-12" isChoice={true}>
+        <DotIndicator isChoosen={isFixed} />
 
-      <div className="flex-1">
-        <CardContent className="p-4 sm:p-6 h-full flex flex-col justify-center">
-          {isCommitted && <StaticChoice {...fakeDefultChoice} />}
+        <div className="flex-1">
+          <CardContent className="p-4 sm:p-6 h-full flex flex-col justify-center">
+            <ThemedInputField
+              placeholder="선택지 제목"
+              labelText=""
+              {...register("title", { required: true })}
+              className={`${errors["title"] ? "border-red-500" : ""}`}
+            />
+            <ThemedTextareaField
+              placeholder="선택지 내용"
+              labelText=""
+              rows={2}
+              {...register("description", { required: true })}
+              className={`${errors["description"] ? "border-red-500" : ""}`}
+            />
+          </CardContent>
+        </div>
 
-          {!isCommitted && (
-            <>
-              <ThemedInputField
-                name="title"
-                placeholder="선택지 제목"
-                value={formData.title}
-                onChange={(e) =>
-                  setFormData({ ...formData, title: e.target.value })
-                }
-              />
-              <ThemedTextareaField
-                name="description"
-                placeholder="선택지 내용"
-                rows={2}
-                value={formData.description}
-                onChange={(e) =>
-                  setFormData({ ...formData, description: e.target.value })
-                }
-              />
-            </>
+        <CardFooter className="flex items-center p-0 pr-4 pt-2 gap-1">
+          {!isFixed && (
+            <ThemedIconButton type="submit">
+              <CheckIcon className="h-8 w-8" />
+            </ThemedIconButton>
           )}
-        </CardContent>
-      </div>
-
-      <CardFooter className="flex items-center p-0 pr-4 pt-2 gap-1">
-        {!isCommitted && (
-          <ThemedIconButton onClick={clickCommit}>
-            <CheckIcon className="h-8 w-8" />
+          <ThemedIconButton onClick={clickRemove}>
+            <Cross2Icon className="h-8 w-8" />
           </ThemedIconButton>
-        )}
-        <ThemedIconButton onClick={clickRemove}>
-          <Cross2Icon className="h-8 w-8" />
-        </ThemedIconButton>
-      </CardFooter>
-    </ThemedCard>
+        </CardFooter>
+      </ThemedCard>
+    </form>
   );
 }

--- a/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
+++ b/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
@@ -1,11 +1,14 @@
 "use client";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
-import { CheckIcon, Cross2Icon } from "@radix-ui/react-icons";
+import { CheckIcon, Cross2Icon, Link2Icon } from "@radix-ui/react-icons";
 import { CardContent, CardFooter } from "@repo/ui/components/ui/Card.tsx";
 import ThemedCard from "@themed/ThemedCard";
 import ThemedIconButton from "@themed/ThemedIconButton";
-import { TempChoiceType } from "@/components/game/builder/GameBuilderContent";
+import {
+  LinkedPageType,
+  TempChoiceType,
+} from "@/components/game/builder/GameBuilderContent";
 import ThemedInputField from "@/components/theme/ui/ThemedInputField";
 import ThemedTextareaField from "@/components/theme/ui/ThemedTextareaField";
 import DotIndicator from "./DotIndicator";
@@ -16,6 +19,8 @@ interface PageCardProps {
   defaultFixed: boolean;
   fixChoice: (partialChoice: TempChoiceType) => void;
   removeChoice: () => void;
+  availablePages: LinkedPageType[];
+  linkedPage: LinkedPageType | undefined;
 }
 
 export default function ChoiceCard({
@@ -23,6 +28,8 @@ export default function ChoiceCard({
   defaultFixed,
   fixChoice,
   removeChoice,
+  availablePages,
+  linkedPage,
 }: PageCardProps) {
   const [isFixed, setIsFixed] = useState(defaultFixed);
 
@@ -39,7 +46,12 @@ export default function ChoiceCard({
   } = useForm({ defaultValues });
 
   const onSubmit = (formData: typeof defaultValues) => {
-    fixChoice(formData);
+    const choice = {
+      ...formData,
+      toPageId: +formData.toPageId,
+    };
+
+    fixChoice(choice);
     setIsFixed(!isFixed);
   };
 
@@ -48,13 +60,19 @@ export default function ChoiceCard({
   };
 
   if (isFixed) {
-    return <StaticChoice {...getValues()} removeChoice={clickRemove} />;
+    return (
+      <StaticChoice
+        {...getValues()}
+        removeChoice={clickRemove}
+        linkedPage={linkedPage}
+      />
+    );
   }
 
   return (
     <form onSubmit={handleSubmit(onSubmit)}>
       <ThemedCard className="relative min-h-24 !ml-12" isChoice={true}>
-        <DotIndicator isChoosen={isFixed} />
+        <DotIndicator isChoosen={isFixed} linkedPage={linkedPage} />
 
         <div className="flex-1">
           <CardContent className="p-4 sm:p-6 h-full flex flex-col justify-center">
@@ -71,6 +89,20 @@ export default function ChoiceCard({
               {...register("description", { required: true })}
               className={`${errors["description"] ? "border-red-500" : ""}`}
             />
+
+            <div className="flex items-center gap-2 justify-end mt-2">
+              <Link2Icon className="h-5 w-5" />
+              <select
+                {...register("toPageId", { required: true })}
+                className={`p-2 shadow-sm border rounded-sm text-xs ${errors["toPageId"] ? "border-red-500" : ""}`}
+              >
+                {availablePages.map((page) => (
+                  <option key={page.pageId} value={page.pageId}>
+                    {page.title}
+                  </option>
+                ))}
+              </select>
+            </div>
           </CardContent>
         </div>
 

--- a/apps/game-builder/src/components/card/choice/DotIndicator.tsx
+++ b/apps/game-builder/src/components/card/choice/DotIndicator.tsx
@@ -1,9 +1,14 @@
+import { LinkedPageType } from "@/components/game/builder/GameBuilderContent";
+import { Link1Icon } from "@radix-ui/react-icons";
+
 export default function DotIndicator({
   isChoosen,
   theme,
+  linkedPage,
 }: {
   isChoosen: boolean;
   theme?: string;
+  linkedPage: LinkedPageType | undefined;
 }) {
   const unChoosenClass =
     theme === "old-game" ? "!w-5 !h-5 -left-[16px]" : "!w-4 !h-4 -left-[8px]";
@@ -12,7 +17,16 @@ export default function DotIndicator({
 
   return (
     <div
-      className={`absolute w-3 h-3 bg-green-500 rounded-full top-1/2 -translate-y-1/2 -left-2 transition-all ${isChoosen ? choosenClass : unChoosenClass}`}
-    ></div>
+      className={`absolute w-4 h-4 bg-green-500 rounded-full top-1/2 -translate-y-1/2 -left-[10px] transition-all ${isChoosen ? choosenClass : unChoosenClass}`}
+    >
+      {isChoosen && (
+        <div className="flex items-center gap-[2px] absolute top-1/2 -translate-y-1/2 left-[2px]">
+          <Link1Icon className="h-3 w-3" color="#ffffff" />
+          <p className="px-1 w-14 text-xs text-green-500 overflow-hidden whitespace-nowrap overflow-ellipsis">
+            {linkedPage?.title}
+          </p>
+        </div>
+      )}
+    </div>
   );
 }

--- a/apps/game-builder/src/components/card/choice/StaticChoice.tsx
+++ b/apps/game-builder/src/components/card/choice/StaticChoice.tsx
@@ -1,18 +1,44 @@
-import { CardDescription, CardTitle } from "@repo/ui/components/ui/Card.tsx";
+import ThemedCard from "@/components/theme/ui/ThemedCard";
+import {
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardTitle,
+} from "@repo/ui/components/ui/Card.tsx";
+import DotIndicator from "./DotIndicator";
+import ThemedIconButton from "@/components/theme/ui/ThemedIconButton";
+import { Cross2Icon } from "@radix-ui/react-icons";
 
 export function StaticChoice({
-  title,
-  description,
+  title = "title 없음",
+  description = "description 없음",
+  removeChoice,
 }: {
   title: string;
   description: string;
+  removeChoice: () => void;
 }) {
+  const clickRemove = () => {
+    if (confirm("삭제 하시겠습니까?")) removeChoice();
+  };
+
   return (
-    <>
-      <CardTitle className="mb-1 !text-[14px] p-[1px]">{title}</CardTitle>
-      <CardDescription className="text-xs line-clamp-4 mb-0 p-[1px]">
-        {description}
-      </CardDescription>
-    </>
+    <ThemedCard className="relative min-h-24 !ml-12" isChoice={true}>
+      <DotIndicator isChoosen={true} />
+      <div className="flex-1">
+        <CardContent className="p-4 sm:p-6 h-full flex flex-col justify-center">
+          <CardTitle className="mb-1 !text-[14px] p-[1px]">{title}</CardTitle>
+          <CardDescription className="text-xs line-clamp-4 mb-0 p-[1px]">
+            {description}
+          </CardDescription>
+        </CardContent>
+      </div>
+
+      <CardFooter className="flex items-center p-0 pr-4 pt-2 gap-1">
+        <ThemedIconButton onClick={clickRemove}>
+          <Cross2Icon className="h-8 w-8" />
+        </ThemedIconButton>
+      </CardFooter>
+    </ThemedCard>
   );
 }

--- a/apps/game-builder/src/components/card/choice/StaticChoice.tsx
+++ b/apps/game-builder/src/components/card/choice/StaticChoice.tsx
@@ -8,15 +8,18 @@ import {
 import DotIndicator from "./DotIndicator";
 import ThemedIconButton from "@/components/theme/ui/ThemedIconButton";
 import { Cross2Icon } from "@radix-ui/react-icons";
+import { LinkedPageType } from "@/components/game/builder/GameBuilderContent";
 
 export function StaticChoice({
   title = "title 없음",
   description = "description 없음",
   removeChoice,
+  linkedPage,
 }: {
   title: string;
   description: string;
   removeChoice: () => void;
+  linkedPage: LinkedPageType | undefined;
 }) {
   const clickRemove = () => {
     if (confirm("삭제 하시겠습니까?")) removeChoice();
@@ -24,7 +27,8 @@ export function StaticChoice({
 
   return (
     <ThemedCard className="relative min-h-24 !ml-12" isChoice={true}>
-      <DotIndicator isChoosen={true} />
+      <DotIndicator isChoosen={true} linkedPage={linkedPage} />
+
       <div className="flex-1">
         <CardContent className="p-4 sm:p-6 h-full flex flex-col justify-center">
           <CardTitle className="mb-1 !text-[14px] p-[1px]">{title}</CardTitle>

--- a/apps/game-builder/src/components/game/builder/GameBuilder.tsx
+++ b/apps/game-builder/src/components/game/builder/GameBuilder.tsx
@@ -1,6 +1,4 @@
 "use client";
-import { FormEvent } from "react";
-import { useRouter } from "next/navigation";
 import { GetAllGameResDto } from "@choosetale/nestia-type/lib/structures/GetAllGameResDto";
 
 import useGameData from "@/hooks/useGameData";
@@ -19,23 +17,17 @@ export default function GameBuilder({
   gameData: TempGetGameResDto;
   gameId: number;
 }) {
-  const router = useRouter();
   const { gameInitData } = useGameStore((state) => state);
   const useGameDataProps = useGameData({ gameInitData, gameAllData, gameData });
 
-  const onSubmit = async (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
-    router.push("/game/confirm");
-  };
-
   return (
-    <form onSubmit={onSubmit} className="flex-1 relative flex px-6 pt-4">
+    <div className="flex-1 relative flex px-6 pt-4">
       <StoryLine />
       <GameSubmitButton />
 
       <div className="flex-1 flex flex-col gap-4 pb-20">
         <GameBuilderContent {...useGameDataProps} gameId={gameId} />
       </div>
-    </form>
+    </div>
   );
 }

--- a/apps/game-builder/src/components/game/builder/GameBuilderContent.tsx
+++ b/apps/game-builder/src/components/game/builder/GameBuilderContent.tsx
@@ -4,6 +4,7 @@ import useClientChoices from "@/hooks/useClientChoices";
 import useGameData from "@/hooks/useGameData";
 import ChoiceCard from "@/components/card/choice/ChoiceCard";
 import PageCard from "@components/card/page/PageCard";
+import { StaticChoice } from "@/components/card/choice/StaticChoice";
 
 interface GameBuilderContentProps extends ReturnType<typeof useGameData> {
   gameId: number;
@@ -18,9 +19,9 @@ export default function GameBuilderContent({
   gameId,
   ...useGameDataProps
 }: GameBuilderContentProps) {
-  const { gamePageData, deleteChoice, addPage, deletePage, addAiChoice } =
+  const { gamePageData, deleteChoice, addPage, deletePage, updateChoices } =
     useGameDataProps;
-  const { clientChoicesMap, addClientChoice, removeClientChoice } =
+  const { clientChoicesMap, addClientChoice, removeClientChoice, addAiChoice } =
     useClientChoices({
       gameData: gamePageData,
     });
@@ -39,8 +40,8 @@ export default function GameBuilderContent({
     console.log("선택지 카드 추가 🤖");
     addAiChoice({ gameId, pageId });
   };
-  const handleCommitChoice = (pageId: number, choice: TempChoiceType) => {
-    console.log("선택 결정");
+  const handleFixChoice = (pageId: number, choice: TempChoiceType) => {
+    console.log("선택 결정", choice);
     // updateChoices(pageId, choice);
   };
   const handleRemoveChoiceOnClient = (pageId: number, choiceId: number) => {
@@ -56,7 +57,10 @@ export default function GameBuilderContent({
   return (
     <div className="flex-1 flex flex-col gap-4">
       {gamePageData.map((page) => {
-        const clientChoice = clientChoicesMap.get(page.id);
+        const choices = page.choices as TempChoiceType[];
+        const clientChoice = clientChoicesMap.get(page.id) as
+          | TempChoiceType[]
+          | undefined;
 
         return (
           <div key={`page${page.id}`} className="flex flex-col gap-4">
@@ -66,15 +70,10 @@ export default function GameBuilderContent({
               addAIChoice={() => handleAddPageAndChoiceByAI(page.id)}
               choicesLength={page.choices.length + (clientChoice?.length ?? 0)}
             />
-            {page.choices.map((choice) => (
-              <ChoiceCard
-                key={`page${page.id}choice${choice.id}`}
-                choice={choice}
-                defaultCommitted={
-                  choice.fromPageId !== undefined &&
-                  choice.toPageId !== undefined
-                }
-                commitChoice={(choice) => handleCommitChoice(page.id, choice)}
+            {choices.map((choice, idx) => (
+              <StaticChoice
+                {...choice}
+                key={`page${page.id}choice${idx}`}
                 removeChoice={() =>
                   handleRemoveChoiceOnData(page.id, choice.id)
                 }
@@ -84,8 +83,8 @@ export default function GameBuilderContent({
               <ChoiceCard
                 key={`page${page.id}clientChoice${idx}`}
                 choice={choice}
-                defaultCommitted={false}
-                commitChoice={(choice) => handleCommitChoice(page.id, choice)}
+                defaultFixed={false}
+                fixChoice={(choice) => handleFixChoice(page.id, choice)}
                 removeChoice={() =>
                   handleRemoveChoiceOnClient(page.id, choice.id)
                 }

--- a/apps/game-builder/src/components/game/builder/GameBuilderContent.tsx
+++ b/apps/game-builder/src/components/game/builder/GameBuilderContent.tsx
@@ -15,16 +15,26 @@ export interface TempChoiceType extends Choice {
   description: string;
 }
 
+export interface LinkedPageType {
+  pageId: number;
+  title: string;
+}
+
 export default function GameBuilderContent({
   gameId,
   ...useGameDataProps
 }: GameBuilderContentProps) {
   const { gamePageData, deleteChoice, addPage, deletePage, updateChoices } =
     useGameDataProps;
-  const { clientChoicesMap, addClientChoice, removeClientChoice, addAiChoice } =
-    useClientChoices({
-      gameData: gamePageData,
-    });
+  const {
+    clientChoicesMap,
+    addClientChoice,
+    removeClientChoice,
+    addAiChoice,
+    updateClientChoice,
+  } = useClientChoices({
+    gameData: gamePageData,
+  });
 
   const handleAddPageAndChoice = (pageId: number, depth: number) => {
     console.log(`POST /game/${gameId}/page 카드 추가`);
@@ -42,7 +52,7 @@ export default function GameBuilderContent({
   };
   const handleFixChoice = (pageId: number, choice: TempChoiceType) => {
     console.log("선택 결정", choice);
-    // updateChoices(pageId, choice);
+    updateClientChoice(pageId, choice);
   };
   const handleRemoveChoiceOnClient = (pageId: number, choiceId: number) => {
     console.log("선택 삭제");
@@ -53,6 +63,13 @@ export default function GameBuilderContent({
     console.log("선택 삭제");
     deleteChoice(pageId, choiceId);
   };
+
+  const availablePages = gamePageData.map((page) => ({
+    pageId: page.id,
+    title: page.abridgement,
+  }));
+  const getToPage = (toPageId: number) =>
+    availablePages.find((p) => p.pageId === toPageId);
 
   return (
     <div className="flex-1 flex flex-col gap-4">
@@ -77,6 +94,7 @@ export default function GameBuilderContent({
                 removeChoice={() =>
                   handleRemoveChoiceOnData(page.id, choice.id)
                 }
+                linkedPage={getToPage(choice.toPageId)}
               />
             ))}
             {clientChoice?.map((choice, idx) => (
@@ -88,6 +106,8 @@ export default function GameBuilderContent({
                 removeChoice={() =>
                   handleRemoveChoiceOnClient(page.id, choice.id)
                 }
+                availablePages={availablePages}
+                linkedPage={getToPage(choice.toPageId)}
               />
             ))}
           </div>

--- a/apps/game-builder/src/hooks/useClientChoices.tsx
+++ b/apps/game-builder/src/hooks/useClientChoices.tsx
@@ -68,8 +68,6 @@ export default function useClientChoices({ gameData }: UseClientChoicesProps) {
       createdAt: new Date().toISOString(),
     };
 
-    console.log(newChoice);
-
     setClientChoicesMap((prevMap) => {
       const existingChoices = prevMap.get(pageId) || [];
       const updatedChoices = [...existingChoices, newChoice];
@@ -79,7 +77,22 @@ export default function useClientChoices({ gameData }: UseClientChoicesProps) {
     });
   };
 
-  const submitClientChoice = () => {};
+  const updateClientChoice = (
+    pageId: number,
+    updatedChoice: Partial<TempChoiceType>
+  ) => {
+    setClientChoicesMap((prevMap) => {
+      const existingChoices = prevMap.get(pageId) || [];
+      const updatedChoices = existingChoices.map((choice) =>
+        choice.id === updatedChoice.id
+          ? { ...choice, ...updatedChoice }
+          : choice
+      );
+      const newMap = new Map(prevMap);
+      newMap.set(pageId, updatedChoices);
+      return newMap;
+    });
+  };
 
   const removeClientChoice = (pageId: number, choiceId: number) => {
     setClientChoicesMap((prevMap) => {
@@ -102,6 +115,6 @@ export default function useClientChoices({ gameData }: UseClientChoicesProps) {
     addAiChoice,
     addClientChoice,
     removeClientChoice,
-    submitClientChoice,
+    updateClientChoice,
   };
 }

--- a/apps/game-builder/src/hooks/useClientChoices.tsx
+++ b/apps/game-builder/src/hooks/useClientChoices.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
 import { Page } from "@choosetale/nestia-type/lib/structures/Page";
 import { Choice } from "@choosetale/nestia-type/lib/structures/Choice";
+import { TempChoiceType } from "@/components/game/builder/GameBuilderContent";
+import { getRecommendChoice } from "@/actions/choice/getRecommendChoice";
 
 interface UseClientChoicesProps {
   gameData: Page[];
@@ -11,7 +13,10 @@ export default function useClientChoices({ gameData }: UseClientChoicesProps) {
     Map<number, Choice[]>
   >(new Map());
 
-  const addClientChoice = (pageId: number): boolean => {
+  const addClientChoice = (
+    pageId: number,
+    choice?: TempChoiceType
+  ): boolean => {
     let success: boolean = false;
     setClientChoicesMap((prevMap) => {
       const actualChoiceLength =
@@ -24,11 +29,13 @@ export default function useClientChoices({ gameData }: UseClientChoicesProps) {
       }
 
       const existingChoices = prevMap.get(pageId) || [];
-      const newChoice: Choice = {
+      const newChoice: TempChoiceType = {
         id: existingChoices.length,
         fromPageId: pageId,
         toPageId: -1,
         createdAt: new Date().toISOString(),
+        title: choice?.title ?? "",
+        description: choice?.description ?? "",
       };
       const updatedChoices = [...existingChoices, newChoice];
       const newMap = new Map(prevMap);
@@ -38,6 +45,38 @@ export default function useClientChoices({ gameData }: UseClientChoicesProps) {
       return newMap;
     });
     return success;
+  };
+  const addAiChoice = async ({
+    gameId,
+    pageId,
+  }: {
+    pageId: number;
+    gameId: number;
+  }) => {
+    const res = await getRecommendChoice({ gameId, pageId });
+    if (!res.success) return;
+
+    const choice = res.choice;
+    const newChoice: TempChoiceType = {
+      ...choice,
+      id:
+        (gameData.find((page) => page.id === pageId)?.choices.length ?? 0) +
+        (clientChoicesMap.get(pageId)?.length ?? 0) +
+        1,
+      fromPageId: pageId,
+      toPageId: -1,
+      createdAt: new Date().toISOString(),
+    };
+
+    console.log(newChoice);
+
+    setClientChoicesMap((prevMap) => {
+      const existingChoices = prevMap.get(pageId) || [];
+      const updatedChoices = [...existingChoices, newChoice];
+      const newMap = new Map(prevMap);
+      newMap.set(pageId, updatedChoices);
+      return newMap;
+    });
   };
 
   const submitClientChoice = () => {};
@@ -60,6 +99,7 @@ export default function useClientChoices({ gameData }: UseClientChoicesProps) {
 
   return {
     clientChoicesMap,
+    addAiChoice,
     addClientChoice,
     removeClientChoice,
     submitClientChoice,

--- a/apps/game-builder/src/hooks/useGameData.tsx
+++ b/apps/game-builder/src/hooks/useGameData.tsx
@@ -5,7 +5,6 @@ import { Page } from "@choosetale/nestia-type/lib/structures/Page";
 import { Choice } from "@choosetale/nestia-type/lib/structures/Choice";
 import { ExtendsPageType, IInitPage } from "@/interface/page";
 import { TempGetGameResDto } from "@/actions/game/getGame";
-import { getRecommendChoice } from "@/actions/choice/getRecommendChoice";
 import { TempChoiceType } from "@/components/game/builder/GameBuilderContent";
 
 export default function useGameData({
@@ -24,43 +23,26 @@ export default function useGameData({
   const [allGame, setAllGame] = useState(initGame ?? gameAllData);
   const [gamePageData, setGamePageData] = useState<Page[]>(allGame?.pages);
 
-  const updateChoices = (pageId: number, choices: TempChoiceType[]) => {};
+  const updateChoices = (pageId: number, updatedChoice: TempChoiceType) => {
+    setGamePageData((prevData) =>
+      prevData.map((page) =>
+        page.id === pageId
+          ? {
+              ...page,
+              choices: page.choices.map((choice) =>
+                choice.id === updatedChoice.id ? updatedChoice : choice
+              ),
+            }
+          : page
+      )
+    );
+  };
 
   const addChoice = (pageId: number, choice: Choice) => {
     setGamePageData((prevData) =>
       prevData.map((page) =>
         page.id === pageId
           ? { ...page, choices: [...page.choices, choice] }
-          : page
-      )
-    );
-  };
-
-  const addAiChoice = async ({
-    gameId,
-    pageId,
-  }: {
-    pageId: number;
-    gameId: number;
-  }) => {
-    // FIXME: Response status is 404
-    const res = await getRecommendChoice({ gameId, pageId });
-    console.log(res);
-
-    // TODO: choice와 page 연결 의논 필요
-
-    const tempChoice = {
-      id:
-        (gamePageData.find((page) => page.id === pageId)?.choices.length ?? 0) +
-        1,
-      fromPageId: 0,
-      toPageId: -1,
-      createdAt: new Date().toISOString(),
-    };
-    setGamePageData((prevData) =>
-      prevData.map((page) =>
-        page.id === pageId
-          ? { ...page, choices: [...page.choices, tempChoice] }
           : page
       )
     );
@@ -119,7 +101,6 @@ export default function useGameData({
     addPage,
     deletePage,
     addChoice,
-    addAiChoice,
     updateChoices,
     deleteChoice,
   };


### PR DESCRIPTION
### 선택지 고정
- [x] 일반 선택지를 고정
- [x] AI 추천 선택지 고정

### vaildation
- [x] 선택지 form 관리 추가
<img width="472" alt="image" src="https://github.com/user-attachments/assets/3ee666e3-6368-4084-94a9-decdda7185ed">

### 선택지에 toPageId 선택 항목 추가

<img width="466" alt="image" src="https://github.com/user-attachments/assets/ef8ab7b9-d32d-47f8-a09d-553d54d40275">

### static choice 출력
- [x] 고정된 static choice 출력, 링크된 페이지 제목 추가
<img width="537" alt="image" src="https://github.com/user-attachments/assets/4c4132e3-7512-48bc-957c-2e85f6612852">
