### PR TITLE
feat(S1): 게임 빌딩 페이지 - 페이지 수정

### DIFF
--- a/apps/game-builder/package.json
+++ b/apps/game-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-builder",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/game-builder/src/actions/action.ts
+++ b/apps/game-builder/src/actions/action.ts
@@ -1,4 +1,4 @@
-import * as type from "@choosetale/nestia-type";
+import { HttpError } from "@choosetale/nestia-type";
 
 export interface SuccessResponse {
   success: true;
@@ -6,5 +6,5 @@ export interface SuccessResponse {
 
 export interface ErrorResponse {
   success: false;
-  error: type.HttpError | Error;
+  error: HttpError | Error;
 }

--- a/apps/game-builder/src/components/card/choice/StaticChoice.tsx
+++ b/apps/game-builder/src/components/card/choice/StaticChoice.tsx
@@ -31,8 +31,10 @@ export function StaticChoice({
 
       <div className="flex-1">
         <CardContent className="p-4 sm:p-6 h-full flex flex-col justify-center">
-          <CardTitle className="mb-1 !text-[14px] p-[1px]">{title}</CardTitle>
-          <CardDescription className="text-xs line-clamp-4 mb-0 p-[1px]">
+          <CardTitle className="mb-1 !text-[14px] p-[1px] break-all">
+            {title}
+          </CardTitle>
+          <CardDescription className="text-xs line-clamp-4 mb-0 p-[1px] break-all">
             {description}
           </CardDescription>
         </CardContent>

--- a/apps/game-builder/src/components/card/page/PageCard.tsx
+++ b/apps/game-builder/src/components/card/page/PageCard.tsx
@@ -36,8 +36,10 @@ export default function PageCard({
 
       <div className="min-h-24 flex-1">
         <CardContent className="p-4 sm:p-6 h-full flex flex-col justify-center">
-          <CardTitle className="mb-1 !text-[16px]">{abridgement}</CardTitle>
-          <CardDescription className="text-xs line-clamp-4 mb-0">
+          <CardTitle className="mb-1 !text-[16px] break-all">
+            {abridgement}
+          </CardTitle>
+          <CardDescription className="text-xs line-clamp-4 mb-0 break-all">
             {description}
           </CardDescription>
         </CardContent>

--- a/apps/game-builder/src/components/card/page/PageCard.tsx
+++ b/apps/game-builder/src/components/card/page/PageCard.tsx
@@ -18,6 +18,7 @@ interface PageCardProps {
   choicesLength: number;
   addChoice: () => void;
   addAIChoice: () => void;
+  updatePage: (updatedPage: Page) => void;
 }
 
 export default function PageCard({
@@ -25,6 +26,7 @@ export default function PageCard({
   choicesLength,
   addChoice,
   addAIChoice,
+  updatePage,
 }: PageCardProps) {
   const { abridgement, description } = page;
 
@@ -56,7 +58,7 @@ export default function PageCard({
         </CardFooter>
       )}
 
-      <GameEditDraw />
+      <GameEditDraw page={page} updatePage={updatePage} />
     </ThemedCard>
   );
 }

--- a/apps/game-builder/src/components/game/builder/GameBuilderContent.tsx
+++ b/apps/game-builder/src/components/game/builder/GameBuilderContent.tsx
@@ -24,7 +24,7 @@ export default function GameBuilderContent({
   gameId,
   ...useGameDataProps
 }: GameBuilderContentProps) {
-  const { gamePageData, deleteChoice, addPage, deletePage, updateChoices } =
+  const { gamePageData, deleteChoice, addPage, updatePage, deletePage } =
     useGameDataProps;
   const {
     clientChoicesMap,
@@ -33,7 +33,7 @@ export default function GameBuilderContent({
     addAiChoice,
     updateClientChoice,
   } = useClientChoices({
-    gameData: gamePageData,
+    gamePageData,
   });
 
   const handleAddPageAndChoice = (pageId: number, depth: number) => {
@@ -83,9 +83,10 @@ export default function GameBuilderContent({
           <div key={`page${page.id}`} className="flex flex-col gap-4">
             <PageCard
               page={page}
+              choicesLength={page.choices.length + (clientChoice?.length ?? 0)}
               addChoice={() => handleAddPageAndChoice(page.id, page.depth + 1)}
               addAIChoice={() => handleAddPageAndChoiceByAI(page.id)}
-              choicesLength={page.choices.length + (clientChoice?.length ?? 0)}
+              updatePage={updatePage}
             />
             {choices.map((choice, idx) => (
               <StaticChoice

--- a/apps/game-builder/src/components/game/create/form/GameCreateFields.tsx
+++ b/apps/game-builder/src/components/game/create/form/GameCreateFields.tsx
@@ -23,8 +23,8 @@ export default function GameCreateFields({ ...useFormProps }: GameFieldsProps) {
 
   const pageContentLen = watch("pageOneContent")?.length || 0;
   const pageContentLenString = formatNumberWithCommas(pageContentLen);
-  const lessThan100LeftForPageContent =
-    MAX_LENGTH.pageOneContent - pageContentLen < 100;
+  const lessThan20LeftForPageContent =
+    MAX_LENGTH.pageOneContent - pageContentLen < 20;
 
   return (
     <>
@@ -55,7 +55,7 @@ export default function GameCreateFields({ ...useFormProps }: GameFieldsProps) {
       <div>
         <p
           className={`relative h-0 top-6 px-1 text-xs text-right ${
-            lessThan100LeftForPageContent ? "text-red-500 border-red-500" : ""
+            lessThan20LeftForPageContent ? "text-red-500 border-red-500" : ""
           }`}
         >
           {pageContentLenString} /{" "}
@@ -75,7 +75,7 @@ export default function GameCreateFields({ ...useFormProps }: GameFieldsProps) {
           },
         })}
         errMsg={errors["pageOneContent"]?.message}
-        className={lessThan100LeftForPageContent ? "text-red-500" : ""}
+        className={lessThan20LeftForPageContent ? "text-red-500" : ""}
       />
     </>
   );

--- a/apps/game-builder/src/components/game/create/form/GameCreateFields.tsx
+++ b/apps/game-builder/src/components/game/create/form/GameCreateFields.tsx
@@ -2,8 +2,13 @@ import { UseFormReturn } from "react-hook-form";
 import { CreateGameReqDto } from "@choosetale/nestia-type/lib/structures/CreateGameReqDto";
 import ThemedInputField from "@themed/ThemedInputField";
 import ThemedTextareaField from "@themed/ThemedTextareaField";
+import { formatNumberWithCommas } from "@/utils/formatNumberWithCommas";
 
 type GameFieldsProps = UseFormReturn<CreateGameReqDto>;
+const MAX_LENGTH = {
+  title: 30,
+  pageOneContent: 2000,
+} as const;
 
 export default function GameCreateFields({ ...useFormProps }: GameFieldsProps) {
   const {
@@ -12,19 +17,14 @@ export default function GameCreateFields({ ...useFormProps }: GameFieldsProps) {
     watch,
   } = useFormProps;
 
-  const formatNumberWithCommas = (value: number) => {
-    return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
-  };
-
   const titleLen = watch("title")?.length || 0;
   const titleLenString = formatNumberWithCommas(titleLen);
-  const MAX_TITLE_LEN = 30;
-  const lessThan3LeftForTitle = MAX_TITLE_LEN - titleLen < 3;
+  const lessThan3LeftForTitle = MAX_LENGTH.title - titleLen < 3;
 
   const pageContentLen = watch("pageOneContent")?.length || 0;
   const pageContentLenString = formatNumberWithCommas(pageContentLen);
-  const MAX_PAGE_LEN = 2000;
-  const lessThan100LeftForPageContent = MAX_PAGE_LEN - pageContentLen < 100;
+  const lessThan100LeftForPageContent =
+    MAX_LENGTH.pageOneContent - pageContentLen < 100;
 
   return (
     <>
@@ -34,16 +34,17 @@ export default function GameCreateFields({ ...useFormProps }: GameFieldsProps) {
             lessThan3LeftForTitle ? "text-red-500" : ""
           }`}
         >
-          {titleLenString} / {MAX_TITLE_LEN}
+          {titleLenString} / {MAX_LENGTH.title}
         </p>
       </div>
       <ThemedInputField
         labelText="게임"
         placeholder="게임 이름 (1~30)"
+        maxLength={MAX_LENGTH.title}
         {...register("title", {
           required: "게임의 이름을 입력해주세요",
           maxLength: {
-            value: 30,
+            value: MAX_LENGTH.title,
             message: "게임 이름을 30자 내로 입력해주세요",
           },
         })}
@@ -57,17 +58,19 @@ export default function GameCreateFields({ ...useFormProps }: GameFieldsProps) {
             lessThan100LeftForPageContent ? "text-red-500 border-red-500" : ""
           }`}
         >
-          {pageContentLenString} / {formatNumberWithCommas(MAX_PAGE_LEN)}
+          {pageContentLenString} /{" "}
+          {formatNumberWithCommas(MAX_LENGTH.pageOneContent)}
         </p>
       </div>
       <ThemedTextareaField
         labelText="이야기의 시작"
         placeholder="첫 페이지의 내용 (2,000자 이내)"
         rows={12}
+        maxLength={MAX_LENGTH.pageOneContent}
         {...register("pageOneContent", {
           required: "첫 페이지의 내용을 작성해주세요",
           maxLength: {
-            value: 2000,
+            value: MAX_LENGTH.pageOneContent,
             message: "2,000자 내로 입력해주세요",
           },
         })}

--- a/apps/game-builder/src/components/game/edit/GameEditDraw.tsx
+++ b/apps/game-builder/src/components/game/edit/GameEditDraw.tsx
@@ -61,7 +61,7 @@ export default function GameEditDraw({
 
           <DrawerFooter className="flex flex-col !px-0 mb-6">
             <ThemedButton className="w-full is-success" type="submit">
-              저장하기
+              수정
             </ThemedButton>
             <DrawerClose
               onClick={() => setIsOpen(false)}

--- a/apps/game-builder/src/components/game/edit/GameEditDraw.tsx
+++ b/apps/game-builder/src/components/game/edit/GameEditDraw.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { SubmitHandler, useForm } from "react-hook-form";
 import {
   Drawer,
   DrawerClose,
@@ -9,29 +9,47 @@ import {
   DrawerHeader,
   DrawerTitle,
 } from "@repo/ui/components/ui/Drawer.tsx";
+import { Page } from "@choosetale/nestia-type/lib/structures/Page";
 import GameEditDrawTriggerButton from "./GameEditDrawTriggerButton";
 import ThemedButton from "@/components/theme/ui/ThemedButton";
 import GameEditFields from "@/components/game/edit/form/GameEditFields";
+import { useState } from "react";
 
-export default function GameEditDraw({ theme }: { theme?: string }) {
-  const [formData, setFormData] = useState({
-    abridgement: "",
-    description: "",
-  });
+interface GameEditDrawProps {
+  theme?: string;
+  page: Page;
+  updatePage: (page: Page) => void;
+}
+export interface GameEditFieldsType {
+  abridgement: string;
+  description: string;
+}
 
-  const updateGameEdit = () => {
-    console.log(formData);
-    console.log("업데이트 저장");
+export default function GameEditDraw({
+  theme,
+  page,
+  updatePage,
+}: GameEditDrawProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const useFormProps = useForm({ defaultValues: page });
+  const { handleSubmit } = useFormProps;
+
+  const onSubmit: SubmitHandler<Page> = (fieldValues) => {
+    updatePage(fieldValues);
+    setIsOpen(false);
   };
 
   return (
-    <Drawer>
+    <Drawer open={isOpen} onOpenChange={setIsOpen}>
       <GameEditDrawTriggerButton />
 
       <DrawerContent
         className={`h-[calc(100vh-3rem)] ${theme === "windows-98" ? "bg-[#c0c0c0]" : ""}`}
       >
-        <div className="w-full max-w-xl h-full mx-auto px-6 flex flex-col gap-4">
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="w-full max-w-xl h-full mx-auto px-6 flex flex-col gap-4"
+        >
           <DrawerHeader className="!px-0 !pt-4 !pb-0">
             <DrawerTitle>이야기 수정하기</DrawerTitle>
             <DrawerDescription className="!mb-0">
@@ -39,21 +57,20 @@ export default function GameEditDraw({ theme }: { theme?: string }) {
             </DrawerDescription>
           </DrawerHeader>
 
-          <GameEditFields formData={formData} setFormData={setFormData} />
+          <GameEditFields {...useFormProps} />
 
           <DrawerFooter className="flex flex-col !px-0 mb-6">
-            <ThemedButton
-              className="w-full is-success"
-              type="submit"
-              onClick={updateGameEdit}
-            >
+            <ThemedButton className="w-full is-success" type="submit">
               저장하기
             </ThemedButton>
-            <DrawerClose className="w-full px-0 text-sm py-2 underline">
+            <DrawerClose
+              onClick={() => setIsOpen(false)}
+              className="w-full px-0 text-sm py-2 underline"
+            >
               닫기
             </DrawerClose>
           </DrawerFooter>
-        </div>
+        </form>
       </DrawerContent>
     </Drawer>
   );

--- a/apps/game-builder/src/components/game/edit/GameEditDraw.tsx
+++ b/apps/game-builder/src/components/game/edit/GameEditDraw.tsx
@@ -13,7 +13,7 @@ import { Page } from "@choosetale/nestia-type/lib/structures/Page";
 import GameEditDrawTriggerButton from "./GameEditDrawTriggerButton";
 import ThemedButton from "@/components/theme/ui/ThemedButton";
 import GameEditFields from "@/components/game/edit/form/GameEditFields";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 interface GameEditDrawProps {
   theme?: string;
@@ -32,10 +32,15 @@ export default function GameEditDraw({
 }: GameEditDrawProps) {
   const [isOpen, setIsOpen] = useState(false);
   const useFormProps = useForm({ defaultValues: page });
-  const { handleSubmit } = useFormProps;
+  const { handleSubmit, reset } = useFormProps;
 
   const onSubmit: SubmitHandler<Page> = (fieldValues) => {
     updatePage(fieldValues);
+    setIsOpen(false);
+  };
+
+  const onClose = () => {
+    reset();
     setIsOpen(false);
   };
 
@@ -64,7 +69,7 @@ export default function GameEditDraw({
               수정
             </ThemedButton>
             <DrawerClose
-              onClick={() => setIsOpen(false)}
+              onClick={onClose}
               className="w-full px-0 text-sm py-2 underline"
             >
               닫기

--- a/apps/game-builder/src/components/game/edit/form/GameEditFields.tsx
+++ b/apps/game-builder/src/components/game/edit/form/GameEditFields.tsx
@@ -20,8 +20,8 @@ export default function GameEditFields({
 
   const pageContentLen = watch("description").length || 0;
   const pageContentLenString = formatNumberWithCommas(pageContentLen);
-  const lessThan100LeftForPageContent =
-    MAX_LENGTH.description - pageContentLen < 100;
+  const lessThan20LeftForPageContent =
+    MAX_LENGTH.description - pageContentLen < 20;
 
   return (
     <>
@@ -46,7 +46,7 @@ export default function GameEditFields({
       <div>
         <p
           className={`relative h-0 top-4 px-1 text-xs text-right ${
-            lessThan100LeftForPageContent ? "text-red-500 border-red-500" : ""
+            lessThan20LeftForPageContent ? "text-red-500 border-red-500" : ""
           }`}
         >
           {pageContentLenString} /{" "}
@@ -67,7 +67,7 @@ export default function GameEditFields({
         })}
         autoComplete="off"
         errMsg={errors["description"]?.message}
-        className={lessThan100LeftForPageContent ? "text-red-500" : ""}
+        className={lessThan20LeftForPageContent ? "text-red-500" : ""}
       />
     </>
   );

--- a/apps/game-builder/src/components/game/edit/form/GameEditFields.tsx
+++ b/apps/game-builder/src/components/game/edit/form/GameEditFields.tsx
@@ -1,43 +1,73 @@
-import { Dispatch, SetStateAction } from "react";
-import { isString } from "@/utils/typeGuard";
+import { useForm } from "react-hook-form";
 import ThemedInputField from "@themed/ThemedInputField";
 import ThemedTextareaField from "@themed/ThemedTextareaField";
+import { formatNumberWithCommas } from "@/utils/formatNumberWithCommas";
+import { Page } from "@choosetale/nestia-type/lib/structures/Page";
 
-interface GameFieldsProps<T> {
-  formData: T;
-  setFormData: Dispatch<SetStateAction<T>>;
-}
+const MAX_LENGTH = {
+  abridgement: 50,
+  description: 3000,
+} as const;
 
-export default function GameEditFields<T extends Record<string, unknown>>({
-  formData,
-  setFormData,
-}: GameFieldsProps<T>) {
-  if (!isString(formData.abridgement) || !isString(formData.description)) {
-    console.assert("GameEditForm requires a title and description");
-    return;
-  }
+export default function GameEditFields({
+  ...useFormProps
+}: ReturnType<typeof useForm<Page>>) {
+  const {
+    register,
+    formState: { errors },
+    watch,
+  } = useFormProps;
+
+  const pageContentLen = watch("description").length || 0;
+  const pageContentLenString = formatNumberWithCommas(pageContentLen);
+  const lessThan100LeftForPageContent =
+    MAX_LENGTH.description - pageContentLen < 100;
 
   return (
     <>
       <ThemedInputField
         labelText="요약"
-        name="abridgement"
-        placeholder="플레이어에게는 보이지 않습니다"
-        value={formData.abridgement}
-        onChange={(e) =>
-          setFormData({ ...formData, abridgement: e.target.value })
-        }
+        placeholder="페이지를 요약해보세요"
+        maxLength={50}
+        {...register("abridgement", {
+          required: "페이지 요약을 입력해주세요",
+          maxLength: {
+            value: 50,
+            message: "요약을 50자 내로 입력해주세요",
+          },
+        })}
+        autoComplete="off"
+        errMsg={errors["abridgement"]?.message ?? ""}
       />
+      <p className="text-xs text-right text-gray-400 h-0 -translate-y-2">
+        요약은 플레이어에게 보이지 않습니다.
+      </p>
 
+      <div>
+        <p
+          className={`relative h-0 top-4 px-1 text-xs text-right ${
+            lessThan100LeftForPageContent ? "text-red-500 border-red-500" : ""
+          }`}
+        >
+          {pageContentLenString} /{" "}
+          {formatNumberWithCommas(MAX_LENGTH.description)}
+        </p>
+      </div>
       <ThemedTextareaField
         labelText="내용"
-        name="description"
-        placeholder="페이지의 내용"
+        placeholder="페이지의 내용을 입력하세요"
         rows={10}
-        value={formData.description}
-        onChange={(e) =>
-          setFormData({ ...formData, description: e.target.value })
-        }
+        maxLength={MAX_LENGTH.description}
+        {...register("description", {
+          required: "페이지 내용을 입력해주세요",
+          maxLength: {
+            value: MAX_LENGTH.description,
+            message: "페이지 내용을 3,000자 내로 입력해주세요",
+          },
+        })}
+        autoComplete="off"
+        errMsg={errors["description"]?.message}
+        className={lessThan100LeftForPageContent ? "text-red-500" : ""}
       />
     </>
   );

--- a/apps/game-builder/src/hooks/useClientChoices.tsx
+++ b/apps/game-builder/src/hooks/useClientChoices.tsx
@@ -5,10 +5,12 @@ import { TempChoiceType } from "@/components/game/builder/GameBuilderContent";
 import { getRecommendChoice } from "@/actions/choice/getRecommendChoice";
 
 interface UseClientChoicesProps {
-  gameData: Page[];
+  gamePageData: Page[];
 }
 
-export default function useClientChoices({ gameData }: UseClientChoicesProps) {
+export default function useClientChoices({
+  gamePageData,
+}: UseClientChoicesProps) {
   const [clientChoicesMap, setClientChoicesMap] = useState<
     Map<number, Choice[]>
   >(new Map());
@@ -20,7 +22,7 @@ export default function useClientChoices({ gameData }: UseClientChoicesProps) {
     let success: boolean = false;
     setClientChoicesMap((prevMap) => {
       const actualChoiceLength =
-        gameData.find((page) => page.id === pageId)?.choices.length ?? 0;
+        gamePageData.find((page) => page.id === pageId)?.choices.length ?? 0;
       const clientChoiceLength = prevMap.get(pageId)?.length ?? 0;
 
       if (actualChoiceLength + clientChoiceLength >= 4) {
@@ -53,14 +55,14 @@ export default function useClientChoices({ gameData }: UseClientChoicesProps) {
     pageId: number;
     gameId: number;
   }) => {
-    const res = await getRecommendChoice({ gameId, pageId });
+    const res = await getRecommendChoice(gameId, pageId);
     if (!res.success) return;
 
     const choice = res.choice;
     const newChoice: TempChoiceType = {
       ...choice,
       id:
-        (gameData.find((page) => page.id === pageId)?.choices.length ?? 0) +
+        (gamePageData.find((page) => page.id === pageId)?.choices.length ?? 0) +
         (clientChoicesMap.get(pageId)?.length ?? 0) +
         1,
       fromPageId: pageId,

--- a/apps/game-builder/src/hooks/useGameData.tsx
+++ b/apps/game-builder/src/hooks/useGameData.tsx
@@ -85,6 +85,12 @@ export default function useGameData({
     setGamePageData((prevData: Page[]) => [...prevData, newPage]);
   };
 
+  const updatePage = (updatedPage: Page) => {
+    setGamePageData((prevData) =>
+      prevData.map((page) => (page.id === updatedPage.id ? updatedPage : page))
+    );
+  };
+
   const deletePage = (pageId: number) => {
     setGamePageData((prevData) => {
       const filteredPages = prevData.filter((page) => page.id !== pageId);
@@ -99,6 +105,7 @@ export default function useGameData({
   return {
     gamePageData,
     addPage,
+    updatePage,
     deletePage,
     addChoice,
     updateChoices,

--- a/apps/game-builder/src/utils/formatNumberWithCommas.ts
+++ b/apps/game-builder/src/utils/formatNumberWithCommas.ts
@@ -1,0 +1,3 @@
+export const formatNumberWithCommas = (number: number) => {
+  return number.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ",");
+};


### PR DESCRIPTION
### 서랍 열기
- [x] 서랍 열기
  - 페이지 수정 버튼을 클릭한다.
- [x] 서랍 닫기
  - 서랍 바깥을 클릭한다.
  - 서랍 닫기 버튼을 클릭한다.
  - 수정 버튼을 클릭한다. 

https://github.com/user-attachments/assets/e5604476-36ae-4902-bea1-63d5f42c760a

### 페이지 수정 로직
- [x] 페이지 수정 인풋에 실제 데이터를 출력하도록 변경
![image](https://github.com/user-attachments/assets/f5434845-89fe-4740-8ad8-7058dce1aab5)

### form 수정: 유효성 검사 및 글자수 UI 추가
- [x] 글자수 UI 추가
![image](https://github.com/user-attachments/assets/52f71c5b-339f-4a5f-9049-f3b05a79aa54)
- [x] vaildation 추가
![image](https://github.com/user-attachments/assets/9c3d48e5-eb8c-4f38-8699-145c1779374c)
![image](https://github.com/user-attachments/assets/fb66bea3-5163-477a-970a-e65e7a51c7b7)
