### PR TITLE
fix(S1): fix select input width CSS in ChoiceCard

### DIFF
--- a/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
+++ b/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
@@ -94,7 +94,7 @@ export default function ChoiceCard({
               <Link2Icon className="h-5 w-5" />
               <select
                 {...register("toPageId", { required: true })}
-                className={`p-2 shadow-sm border rounded-sm text-xs ${errors["toPageId"] ? "border-red-500" : ""}`}
+                className={`p-2 shadow-sm border rounded-sm text-xs w-full ${errors["toPageId"] ? "border-red-500" : ""}`}
               >
                 {availablePages.map((page) => (
                   <option key={page.pageId} value={page.pageId}>


### PR DESCRIPTION
- 선택지와 연결된 페이지 제목 select에 나타나는 글자 길이가 길어지는 경우, 가로 스크롤이 생기는 점 수정함

![image](https://github.com/user-attachments/assets/f4df01b2-6cce-46ac-88aa-38cd6cd3d48b)
