### PR TITLE
feat(S1): 선택지 수정, 버튼 아이콘 업데이트

### DIFF
--- a/apps/game-builder/package.json
+++ b/apps/game-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-builder",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
+++ b/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
-import { CheckIcon, Cross2Icon, Link2Icon } from "@radix-ui/react-icons";
+import { CheckIcon, Link2Icon, TrashIcon } from "@radix-ui/react-icons";
 import { CardContent, CardFooter } from "@repo/ui/components/ui/Card.tsx";
 import ThemedCard from "@themed/ThemedCard";
 import ThemedIconButton from "@themed/ThemedIconButton";
@@ -55,15 +55,19 @@ export default function ChoiceCard({
     setIsFixed(!isFixed);
   };
 
-  const clickRemove = () => {
-    removeChoice();
+  const handleRemove = () => {
+    if (confirm("삭제 하시겠습니까?")) removeChoice();
+  };
+  const handleEdit = () => {
+    setIsFixed(false);
   };
 
   if (isFixed) {
     return (
       <StaticChoice
         {...getValues()}
-        removeChoice={clickRemove}
+        removeChoice={handleRemove}
+        editChoice={handleEdit}
         linkedPage={linkedPage}
       />
     );
@@ -106,14 +110,14 @@ export default function ChoiceCard({
           </CardContent>
         </div>
 
-        <CardFooter className="flex items-center p-0 pr-4 pt-2 gap-1">
+        <CardFooter className="flex flex-col justify-center items-center p-0 pr-4 pt-2 gap-1">
           {!isFixed && (
             <ThemedIconButton type="submit">
               <CheckIcon className="h-8 w-8" />
             </ThemedIconButton>
           )}
-          <ThemedIconButton onClick={clickRemove}>
-            <Cross2Icon className="h-8 w-8" />
+          <ThemedIconButton onClick={handleRemove}>
+            <TrashIcon className="h-7 w-7 m-[2px]" />
           </ThemedIconButton>
         </CardFooter>
       </ThemedCard>

--- a/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
+++ b/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
@@ -1,7 +1,13 @@
 "use client";
 import { useState } from "react";
 import { useForm } from "react-hook-form";
-import { CheckIcon, Link2Icon, TrashIcon } from "@radix-ui/react-icons";
+import {
+  CheckIcon,
+  Cross2Icon,
+  Link2Icon,
+  LockOpen2Icon,
+  TrashIcon,
+} from "@radix-ui/react-icons";
 import { CardContent, CardFooter } from "@repo/ui/components/ui/Card.tsx";
 import ThemedCard from "@themed/ThemedCard";
 import ThemedIconButton from "@themed/ThemedIconButton";
@@ -32,6 +38,7 @@ export default function ChoiceCard({
   linkedPage,
 }: PageCardProps) {
   const [isFixed, setIsFixed] = useState(defaultFixed);
+  const isSavedChoice = defaultFixed === true;
 
   const defaultValues = {
     ...choice,
@@ -56,10 +63,13 @@ export default function ChoiceCard({
   };
 
   const handleRemove = () => {
-    if (confirm("삭제 하시겠습니까?")) removeChoice();
+    if (confirm("선택지를 삭제 하시겠습니까?")) removeChoice();
   };
   const handleEdit = () => {
     setIsFixed(false);
+  };
+  const handleCancel = () => {
+    if (confirm("작성을 취소 하겠습니까?")) setIsFixed(true);
   };
 
   if (isFixed) {
@@ -79,7 +89,7 @@ export default function ChoiceCard({
         <DotIndicator isChoosen={isFixed} linkedPage={linkedPage} />
 
         <div className="flex-1">
-          <CardContent className="p-4 sm:p-6 h-full flex flex-col justify-center">
+          <CardContent className="py-2 !pb-3 px-4 sm:p-6 h-full flex flex-col justify-center">
             <ThemedInputField
               placeholder="선택지 제목"
               labelText=""
@@ -110,14 +120,31 @@ export default function ChoiceCard({
           </CardContent>
         </div>
 
-        <CardFooter className="flex flex-col justify-center items-center p-0 pr-4 pt-2 gap-1">
-          {!isFixed && (
-            <ThemedIconButton type="submit">
-              <CheckIcon className="h-8 w-8" />
+        <CardFooter className="flex flex-col justify-end items-center p-0 pr-4 py-4 gap-2">
+          {isSavedChoice && (
+            <ThemedIconButton
+              type="submit"
+              className="!absolute top-1 right-1 min-w-6 p-0 min-h-0 px-2 py-[2px]"
+            >
+              <LockOpen2Icon className="h-4 w-4" />
             </ThemedIconButton>
           )}
+          {!isSavedChoice && (
+            <ThemedIconButton
+              type="submit"
+              className="!absolute top-1 right-1 min-w-6 p-0 min-h-0 px-2 py-[2px]"
+            >
+              <CheckIcon className="h-6 w-6" />
+            </ThemedIconButton>
+          )}
+          {isSavedChoice && (
+            <ThemedIconButton onClick={handleCancel}>
+              <Cross2Icon className="h-6 w-6" />
+            </ThemedIconButton>
+          )}
+
           <ThemedIconButton onClick={handleRemove}>
-            <TrashIcon className="h-7 w-7 m-[2px]" />
+            <TrashIcon className="h-5 w-5 m-[1px]" />
           </ThemedIconButton>
         </CardFooter>
       </ThemedCard>

--- a/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
+++ b/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
@@ -50,6 +50,7 @@ export default function ChoiceCard({
     handleSubmit,
     getValues,
     formState: { errors },
+    reset,
   } = useForm({ defaultValues });
 
   const onSubmit = (formData: typeof defaultValues) => {
@@ -70,6 +71,7 @@ export default function ChoiceCard({
   };
   const handleCancel = () => {
     setIsFixed(true);
+    reset(choice);
   };
 
   if (isFixed) {

--- a/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
+++ b/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
@@ -69,7 +69,7 @@ export default function ChoiceCard({
     setIsFixed(false);
   };
   const handleCancel = () => {
-    if (confirm("작성을 취소 하겠습니까?")) setIsFixed(true);
+    setIsFixed(true);
   };
 
   if (isFixed) {

--- a/apps/game-builder/src/components/card/choice/StaticChoice.tsx
+++ b/apps/game-builder/src/components/card/choice/StaticChoice.tsx
@@ -7,21 +7,23 @@ import {
 } from "@repo/ui/components/ui/Card.tsx";
 import DotIndicator from "./DotIndicator";
 import ThemedIconButton from "@/components/theme/ui/ThemedIconButton";
-import { Cross2Icon } from "@radix-ui/react-icons";
+import { Pencil2Icon, TrashIcon } from "@radix-ui/react-icons";
 import { LinkedPageType } from "@/components/game/builder/GameBuilderContent";
 
 export function StaticChoice({
   title = "title 없음",
   description = "description 없음",
   removeChoice,
+  editChoice,
   linkedPage,
 }: {
   title: string;
   description: string;
   removeChoice: () => void;
+  editChoice: () => void;
   linkedPage: LinkedPageType | undefined;
 }) {
-  const clickRemove = () => {
+  const onClickRemove = () => {
     if (confirm("삭제 하시겠습니까?")) removeChoice();
   };
 
@@ -41,8 +43,14 @@ export function StaticChoice({
       </div>
 
       <CardFooter className="flex items-center p-0 pr-4 pt-2 gap-1">
-        <ThemedIconButton onClick={clickRemove}>
-          <Cross2Icon className="h-8 w-8" />
+        <ThemedIconButton
+          onClick={editChoice}
+          className="!absolute top-1 right-1 min-w-6 p-0 min-h-0 px-2 py-[2px]"
+        >
+          <Pencil2Icon className="h-4 w-4" />
+        </ThemedIconButton>
+        <ThemedIconButton onClick={onClickRemove}>
+          <TrashIcon className="h-7 w-7 m-[2px]" />
         </ThemedIconButton>
       </CardFooter>
     </ThemedCard>

--- a/apps/game-builder/src/components/card/choice/StaticChoice.tsx
+++ b/apps/game-builder/src/components/card/choice/StaticChoice.tsx
@@ -7,7 +7,7 @@ import {
 } from "@repo/ui/components/ui/Card.tsx";
 import DotIndicator from "./DotIndicator";
 import ThemedIconButton from "@/components/theme/ui/ThemedIconButton";
-import { Pencil2Icon, TrashIcon } from "@radix-ui/react-icons";
+import {LockClosedIcon, TrashIcon } from "@radix-ui/react-icons";
 import { LinkedPageType } from "@/components/game/builder/GameBuilderContent";
 
 export function StaticChoice({
@@ -47,7 +47,7 @@ export function StaticChoice({
           onClick={editChoice}
           className="!absolute top-1 right-1 min-w-6 p-0 min-h-0 px-2 py-[2px]"
         >
-          <Pencil2Icon className="h-4 w-4" />
+          <LockClosedIcon className="h-4 w-4" />
         </ThemedIconButton>
         <ThemedIconButton onClick={onClickRemove}>
           <TrashIcon className="h-7 w-7 m-[2px]" />

--- a/apps/game-builder/src/components/game/builder/GameBuilderContent.tsx
+++ b/apps/game-builder/src/components/game/builder/GameBuilderContent.tsx
@@ -23,8 +23,14 @@ export default function GameBuilderContent({
   gameId,
   ...useGameDataProps
 }: GameBuilderContentProps) {
-  const { gamePageData, deleteChoice, addPage, updatePage, deletePage } =
-    useGameDataProps;
+  const {
+    gamePageData,
+    deleteChoice,
+    addPage,
+    updatePage,
+    deletePage,
+    updateChoices,
+  } = useGameDataProps;
   const {
     clientChoicesMap,
     addClientChoice,
@@ -50,11 +56,14 @@ export default function GameBuilderContent({
     addAiChoice({ gameId, pageId });
   };
   const handleFixChoice = (pageId: number, choice: TempChoiceType) => {
-    updateClientChoice(pageId, choice);
+    updateChoices(pageId, choice);
   };
   const handleRemoveChoiceOnClient = (pageId: number, choiceId: number) => {
     removeClientChoice(pageId, choiceId);
     deletePage(pageId);
+  };
+  const handleFixChoiceOnClient = (pageId: number, choice: TempChoiceType) => {
+    updateClientChoice(pageId, choice);
   };
   const handleRemoveChoiceOnData = (pageId: number, choiceId: number) => {
     deleteChoice(pageId, choiceId);
@@ -102,7 +111,7 @@ export default function GameBuilderContent({
                 key={`page${page.id}clientChoice${idx}`}
                 choice={choice}
                 defaultFixed={false}
-                fixChoice={(choice) => handleFixChoice(page.id, choice)}
+                fixChoice={(choice) => handleFixChoiceOnClient(page.id, choice)}
                 removeChoice={() =>
                   handleRemoveChoiceOnClient(page.id, choice.id)
                 }

--- a/apps/game-builder/src/components/game/builder/GameBuilderContent.tsx
+++ b/apps/game-builder/src/components/game/builder/GameBuilderContent.tsx
@@ -4,7 +4,6 @@ import useClientChoices from "@/hooks/useClientChoices";
 import useGameData from "@/hooks/useGameData";
 import ChoiceCard from "@/components/card/choice/ChoiceCard";
 import PageCard from "@components/card/page/PageCard";
-import { StaticChoice } from "@/components/card/choice/StaticChoice";
 
 interface GameBuilderContentProps extends ReturnType<typeof useGameData> {
   gameId: number;
@@ -51,16 +50,13 @@ export default function GameBuilderContent({
     addAiChoice({ gameId, pageId });
   };
   const handleFixChoice = (pageId: number, choice: TempChoiceType) => {
-    console.log("선택 결정", choice);
     updateClientChoice(pageId, choice);
   };
   const handleRemoveChoiceOnClient = (pageId: number, choiceId: number) => {
-    console.log("선택 삭제");
     removeClientChoice(pageId, choiceId);
     deletePage(pageId);
   };
   const handleRemoveChoiceOnData = (pageId: number, choiceId: number) => {
-    console.log("선택 삭제");
     deleteChoice(pageId, choiceId);
   };
 
@@ -89,12 +85,15 @@ export default function GameBuilderContent({
               updatePage={updatePage}
             />
             {choices.map((choice, idx) => (
-              <StaticChoice
-                {...choice}
+              <ChoiceCard
                 key={`page${page.id}choice${idx}`}
+                choice={choice}
+                defaultFixed={true}
+                fixChoice={(choice) => handleFixChoice(page.id, choice)}
                 removeChoice={() =>
                   handleRemoveChoiceOnData(page.id, choice.id)
                 }
+                availablePages={availablePages}
                 linkedPage={getToPage(choice.toPageId)}
               />
             ))}

--- a/apps/game-builder/src/components/game/edit/GameEditDrawTriggerButton.tsx
+++ b/apps/game-builder/src/components/game/edit/GameEditDrawTriggerButton.tsx
@@ -1,4 +1,4 @@
-import { Pencil2Icon } from "@radix-ui/react-icons";
+import { ReaderIcon } from "@radix-ui/react-icons";
 import { DrawerTrigger } from "@repo/ui/components/ui/Drawer.tsx";
 
 export default function GameEditDrawTriggerButton({
@@ -7,8 +7,8 @@ export default function GameEditDrawTriggerButton({
   theme?: string;
 }) {
   return (
-    <DrawerTrigger className="!absolute top-1 right-1 min-w-6 p-0 min-h-0 px-2 py-[2px]">
-      {theme === "windows-98" ? "수정" : <Pencil2Icon className="h-4 w-4" />}
+    <DrawerTrigger className="!absolute top-2 right-1 min-w-6 p-0 min-h-0 px-2 py-[2px]">
+      {theme === "windows-98" ? "수정" : <ReaderIcon className="h-4 w-4" />}
     </DrawerTrigger>
   );
 }

--- a/apps/game-builder/src/components/theme/ui/ThemedIconButton.tsx
+++ b/apps/game-builder/src/components/theme/ui/ThemedIconButton.tsx
@@ -30,7 +30,7 @@ export default function ThemedIconButton({
     <div className={`relative ${className}`}>
       <button
         type="button"
-        className={`absolute w-full h-full min-w-0 left-0 ${themeClass} ${parentThemeClass}`}
+        className={`absolute w-full h-full min-w-0 left-0 outline-none ${themeClass} ${parentThemeClass}`}
         {...props}
       />
       <div className="relative p-1 pointer-events-none">{children}</div>


### PR DESCRIPTION
```
"name": "game-builder",
"version": "0.0.12",
```
https://github.com/user-attachments/assets/13c7e53f-03cd-4915-96c4-fe74af880288

## 선택지 수정

- [x] 선택지 수정 모드
![image](https://github.com/user-attachments/assets/cd14d7ca-1f5f-42ff-81de-17789f3f81cd)
- [x] 선택지 수정 완료
  - 입력 사항이 저장됨
- [x] 선택지 수정 취소
  - 입력 사항이 저장 되지 않음

## 버튼 아이콘 업데이트

- 선택지 삭제 CrossIcon: 수정 취소 버튼과 혼동될 수 있으므로 TrashIcon으로 변경
![image](https://github.com/user-attachments/assets/488ea7bb-72ae-43f4-9b32-750a6fe06440)
- 페이지 수정 버튼: 상세 페이지의 전체 내용 draw가 열리는 점을 반영하여 ReaderIcon으로 변경
![image](https://github.com/user-attachments/assets/c2088de9-7a34-4cfe-ac01-b4690c34cdee)
- 선택지 수정 버튼: fix, unfix에 맞도록 자물쇠 아이콘으로 변경
![image](https://github.com/user-attachments/assets/b755a60d-2db0-49e3-bf55-ac029c7370f0)
![image](https://github.com/user-attachments/assets/7f04de36-a78e-4c89-9429-282e22719304)
