### PR TITLE
fix(S1): 미연결 페이지 배열 길이 반영

### DIFF
--- a/apps/game-builder/src/components/game/builder/UnLinkedPages.tsx
+++ b/apps/game-builder/src/components/game/builder/UnLinkedPages.tsx
@@ -14,13 +14,14 @@ export default function UnLinkedPages({
   handleDeletePage: (pageId: number) => void;
 }) {
   const unLinkedPagesList = gamePageList.filter((page) => page.depth === -1);
+  if (!unLinkedPagesList.length) return;
 
   return (
     <div className="flex flex-col">
       <div className="flex gap-1 justify-end my-2">
         <h4 className="text-xs">미연결 페이지</h4>
         <div className="w-4 h-4 flex justify-center items-center rounded-full bg-green-400 text-white text-xs">
-          3
+          {unLinkedPagesList.length}
         </div>
       </div>
       <div className="relative w-full flex flex-col gap-2">


### PR DESCRIPTION
- [x] 미연결 페이지가 없을 때
<img src="https://github.com/user-attachments/assets/747c8de7-e920-4634-be76-9cf4f2eb778b" width="400" />

- [x] 미연결 페이지가 있을 때
<img src="https://github.com/user-attachments/assets/f95fd71c-7170-494a-ade7-afaa522ba474" width="400" />
