### PR TITLE
feat(S1): 게임 confirm Form 데이터 연결

### DIFF
--- a/apps/game-builder/next.config.js
+++ b/apps/game-builder/next.config.js
@@ -31,6 +31,10 @@ const nextConfig = {
         protocol: "https",
         hostname: "images.unsplash.com",
       },
+      {
+        protocol: "https",
+        hostname: "www.google.com",
+      },
     ],
   },
 };

--- a/apps/game-builder/package.json
+++ b/apps/game-builder/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@radix-ui/react-icons": "^1.3.0",
     "@tailwindcss/line-clamp": "^0.4.4",
+    "date-fns": "^3.6.0",
     "framer-motion": "^11.3.2",
     "nestia": "^5.3.0",
     "next": "^14.2.3",

--- a/apps/game-builder/src/actions/game/getGame.ts
+++ b/apps/game-builder/src/actions/game/getGame.ts
@@ -2,12 +2,12 @@
 import type { HttpError } from "@choosetale/nestia-type";
 import type { GetAllGameResDto as GetGameAllResDto } from "@choosetale/nestia-type/lib/structures/GetAllGameResDto";
 import { API_URL } from "@/constant/config";
-import type { ExtendsCreateGameResDto } from "@/interface/newGameData";
+import type { GameInfo } from "@/interface/customType";
 import type { ErrorResponse, SuccessResponse } from "../action";
 
 // --게임 정보 불러오기--
 interface GetGameDataSuccessResponse extends SuccessResponse {
-  gameInfo: ExtendsCreateGameResDto;
+  gameInfo: GameInfo;
 }
 export type GetGameDataResponse = GetGameDataSuccessResponse | ErrorResponse;
 
@@ -23,7 +23,7 @@ export const getGameInfoById = async (
       mode: "no-cors",
     });
 
-    const gameInfo = (await response.json()) as ExtendsCreateGameResDto;
+    const gameInfo = (await response.json()) as GameInfo;
     return { success: true, gameInfo };
   } catch (error) {
     return { success: false, error: error as HttpError };

--- a/apps/game-builder/src/app/confirm/[id]/page.tsx
+++ b/apps/game-builder/src/app/confirm/[id]/page.tsx
@@ -1,0 +1,19 @@
+import { notFound } from "next/navigation";
+import ConfirmGame from "@/components/game/confirm/ConfirmGame";
+import { getGameInfoById } from "@/actions/game/getGame";
+
+export default async function Page({ params }: { params: { id: string } }) {
+  const { id } = params;
+  const gameId = Number(id);
+  const gameInfoResponse = await getGameInfoById(id);
+
+  if (isNaN(gameId) || !gameInfoResponse.success) {
+    notFound();
+  }
+
+  return (
+    <div className="w-full px-12 pt-4 pb-10">
+      <ConfirmGame gameId={gameId} gameInfoData={gameInfoResponse.gameInfo} />
+    </div>
+  );
+}

--- a/apps/game-builder/src/app/confirm/page.tsx
+++ b/apps/game-builder/src/app/confirm/page.tsx
@@ -1,9 +1,0 @@
-import ConfirmGame from "@/components/game/confirm/ConfirmGame";
-
-export default function Page() {
-  return (
-    <div className="w-full px-12 pt-4 pb-10">
-      <ConfirmGame />
-    </div>
-  );
-}

--- a/apps/game-builder/src/components/common/form/MaxLengthText.tsx
+++ b/apps/game-builder/src/components/common/form/MaxLengthText.tsx
@@ -1,0 +1,40 @@
+import { formatNumberWithCommas } from "@/utils/formatNumberWithCommas";
+
+interface MaxLengthTextProps {
+  contentLength: number;
+  maxLength: number;
+  isLessThan: boolean;
+  className?: string;
+}
+
+export default function MaxLengthText({
+  contentLength,
+  maxLength,
+  isLessThan,
+  className,
+}: MaxLengthTextProps) {
+  return (
+    <div>
+      <p
+        className={`relative h-0 px-1 text-xs text-right ${
+          isLessThan ? "text-red-500 border-red-500" : ""
+        } ${className}`}
+      >
+        {formatNumberWithCommas(contentLength)} /{" "}
+        {formatNumberWithCommas(maxLength)}
+      </p>
+    </div>
+  );
+}
+
+export function setMaxLengthOptions(
+  contentLength: number,
+  maxLength: number,
+  lessThan: number
+) {
+  return {
+    contentLength,
+    maxLength,
+    isLessThan: maxLength - contentLength < lessThan,
+  };
+}

--- a/apps/game-builder/src/components/common/text/DateDisplay.tsx
+++ b/apps/game-builder/src/components/common/text/DateDisplay.tsx
@@ -1,0 +1,13 @@
+import { format } from "date-fns";
+
+export default function DateDisplay({
+  date,
+  formatStr = "yyyy-MM-dd",
+}: {
+  date: string;
+  formatStr?: string;
+}) {
+  const formattedDate = format(new Date(date), formatStr);
+
+  return <>{formattedDate}</>;
+}

--- a/apps/game-builder/src/components/common/text/TextWithCounts.tsx
+++ b/apps/game-builder/src/components/common/text/TextWithCounts.tsx
@@ -1,0 +1,23 @@
+export default function TextWithCounts({
+  text,
+  counts,
+  color,
+}: {
+  text: string;
+  counts: number;
+  color?: string;
+}) {
+  const displayCounts = counts > 99 ? "99+" : counts;
+
+  return (
+    <div className="flex gap-1 items-center">
+      <span className="text-xs">{text}</span>
+      <div
+        className={`w-4 h-4 flex justify-center items-center rounded-full bg-green-400 text-white text-[10px] font-bold ${counts > 99 ? "px-4" : ""}`}
+        style={{ color }}
+      >
+        {displayCounts}
+      </div>
+    </div>
+  );
+}

--- a/apps/game-builder/src/components/game/builder/UnLinkedPages.tsx
+++ b/apps/game-builder/src/components/game/builder/UnLinkedPages.tsx
@@ -46,7 +46,7 @@ export default function UnLinkedPages({
           </div>
         ))}
       </div>
-      <div className="w-1/3 mx-auto mt-4 text-center border-[#49de7f] border-b-2 border-dashed"></div>
+      <div className="w-1/3 mx-auto mt-4 text-center border-[#49de7f] border-b-2 border-dashed" />
     </div>
   );
 }

--- a/apps/game-builder/src/components/game/builder/UnLinkedPages.tsx
+++ b/apps/game-builder/src/components/game/builder/UnLinkedPages.tsx
@@ -2,6 +2,7 @@ import { TrashIcon } from "@radix-ui/react-icons";
 import type { PageType } from "@/interface/customType";
 import type useGameData from "@/hooks/useGameData";
 import ThemedIconButton from "@/components/theme/ui/ThemedIconButton";
+import TextWithCounts from "@/components/common/text/TextWithCounts";
 import GameEditDraw from "../edit/GameEditDraw";
 
 export default function UnLinkedPages({
@@ -19,10 +20,10 @@ export default function UnLinkedPages({
   return (
     <div className="flex flex-col">
       <div className="flex gap-1 justify-end my-2">
-        <h4 className="text-xs">미연결 페이지</h4>
-        <div className="w-4 h-4 flex justify-center items-center rounded-full bg-green-400 text-white text-xs">
-          {unLinkedPagesList.length}
-        </div>
+        <TextWithCounts
+          text="미연결 페이지"
+          counts={unLinkedPagesList.length}
+        />
       </div>
       <div className="relative w-full flex flex-col gap-2">
         {unLinkedPagesList.map((page) => (

--- a/apps/game-builder/src/components/game/confirm/ConfirmGame.tsx
+++ b/apps/game-builder/src/components/game/confirm/ConfirmGame.tsx
@@ -1,31 +1,39 @@
 "use client";
-import type { FormEvent } from "react";
-import { useState } from "react";
 import { useRouter } from "next/navigation";
+import type { SubmitHandler } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import NextButton from "@components/button/SubmitButton";
 import GameConfirmFields from "@/components/game/confirm/form/GameConfirmFields";
+import type { GameInfo } from "@/interface/customType";
 
-export default function ConirmGame() {
-  const [formData, setFormData] = useState({
-    title: "",
-    description: "",
-    genre: "FANTASY",
-    thumbnailImageId: 0,
-    isPrivate: true,
-  });
+export default function ConirmGame({
+  gameInfoData,
+  gameId,
+}: {
+  gameInfoData: GameInfo;
+  gameId: number;
+}) {
   const router = useRouter();
+  const useFormProps = useForm({ defaultValues: gameInfoData });
+  const { handleSubmit, getValues } = useFormProps;
 
-  const onSubmit = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const onSubmit: SubmitHandler<GameInfo> = (fieldValues) => {
+    // eslint-disable-next-line no-console -- API 연결 전 form 작업
+    console.log(gameId, fieldValues);
     router.push("/");
   };
 
   return (
-    <form onSubmit={onSubmit} className="flex flex-col py-0 gap-6">
-      <GameConfirmFields formData={formData} setFormData={setFormData} />
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="flex flex-col py-0 gap-6"
+    >
+      <GameConfirmFields {...useFormProps} />
 
       <div className="w-full flex">
-        <NextButton text={formData.isPrivate ? "비공개 저장" : "퍼블리시"} />
+        <NextButton
+          text={getValues("isPrivate") ? "비공개 저장" : "퍼블리시"}
+        />
       </div>
     </form>
   );

--- a/apps/game-builder/src/components/game/confirm/form/GameConfirmFields.tsx
+++ b/apps/game-builder/src/components/game/confirm/form/GameConfirmFields.tsx
@@ -1,49 +1,74 @@
-import type { Dispatch, SetStateAction } from "react";
-import { ImageIcon, TrashIcon } from "@radix-ui/react-icons";
 import Image from "next/image";
-import { isBoolean, isString } from "@/utils/typeGuard";
+import type { useForm } from "react-hook-form";
+import { ImageIcon, TrashIcon } from "@radix-ui/react-icons";
 import ThemedInputField from "@themed/ThemedInputField";
 import ThemedTextareaField from "@themed/ThemedTextareaField";
 import ThemedSwitch from "@themed/ThemedSwitch";
+import type { GameInfo } from "@/interface/customType";
 import robotIcon from "@asset/icon/robot-solid.svg";
+import { formatNumberWithCommas } from "@/utils/formatNumberWithCommas";
+import MaxLengthText, {
+  setMaxLengthOptions,
+} from "@/components/common/form/MaxLengthText";
 import ThemedCarousel from "../../../theme/ui/ThemedCarousel";
 import ThemedSelectField from "../../../theme/ui/ThemedSelectField";
 import ThemedIconButton from "../../../theme/ui/ThemedIconButton";
 import ThemedLabel from "../../../theme/ui/ThemedLabel";
 import ThemedCard from "../../../theme/ui/ThemedCard";
 
-interface GameFieldsProps<T> {
-  formData: T;
-  setFormData: Dispatch<SetStateAction<T>>;
-}
+const MAX_LENGTH = {
+  title: 50,
+  description: 2000,
+} as const;
 
-export default function GameConfirmFields<T extends Record<string, unknown>>({
-  formData,
-  setFormData,
-}: GameFieldsProps<T>) {
-  if (
-    !isString(formData.title) ||
-    !isString(formData.description) ||
-    !isString(formData.genre) ||
-    !isBoolean(formData.isPrivate)
-  ) {
-    return;
-  }
+export default function GameConfirmFields({
+  ...useFormProps
+}: ReturnType<typeof useForm<GameInfo>>) {
+  const {
+    register,
+    formState: { errors },
+    watch,
+    getValues,
+    control,
+  } = useFormProps;
+
+  const titleContentLen = watch("title").length || 0;
+  const titleMaxLengthOptions = setMaxLengthOptions(
+    titleContentLen,
+    MAX_LENGTH.title,
+    20
+  );
+
+  const descriptioContentLen = watch("description").length || 0;
+  const descriptionMaxLengthOptions = setMaxLengthOptions(
+    descriptioContentLen,
+    MAX_LENGTH.description,
+    20
+  );
 
   return (
     <>
+      <MaxLengthText {...titleMaxLengthOptions} className="top-7" />
       <ThemedInputField
-        labelText="게임"
-        name="title"
-        placeholder="게임 제목"
-        value={formData.title}
-        onChange={(e) => setFormData({ ...formData, title: e.target.value })}
+        labelText="제목"
+        placeholder="게임의 제목을 입력하세요"
+        maxLength={MAX_LENGTH.title}
+        {...register("title", {
+          required: "게임의 제목을 입력해주세요",
+          maxLength: {
+            value: MAX_LENGTH.title,
+            message: `제목을 ${MAX_LENGTH.title}자 내로 입력해주세요`,
+          },
+        })}
+        autoComplete="off"
+        errMsg={errors.title?.message ?? ""}
       />
 
       <div className="flex flex-col gap-2">
         <ThemedLabel htmlFor="" labelText="썸네일" />
         <ThemedCard className="flex-col !py-4 gap-4">
-          <ThemedCarousel />
+          <ThemedCarousel thumbnails={getValues("thumbnails")} />
+
           <div className="flex justify-center gap-1">
             <ThemedIconButton>
               <ImageIcon className="h-5 w-5 m-1" />
@@ -62,34 +87,27 @@ export default function GameConfirmFields<T extends Record<string, unknown>>({
         </ThemedCard>
       </div>
 
-      <ThemedSelectField
-        labelText="게임 장르"
-        name="genre"
-        placeholder="장르"
-        value={formData.genre}
-        onChange={(e) => setFormData({ ...formData, genre: e.target.value })}
-      />
+      <ThemedSelectField name="genre" labelText="게임 장르" control={control} />
 
+      <MaxLengthText {...descriptionMaxLengthOptions} className="top-6" />
       <ThemedTextareaField
         labelText="게임 소개"
-        name="description"
-        placeholder="게임의 내용을 소개해주세요"
+        placeholder={`게임을 소개해주세요 (${formatNumberWithCommas(MAX_LENGTH.description)}자 내)`}
         rows={6}
-        value={formData.description}
-        onChange={(e) =>
-          setFormData({ ...formData, description: e.target.value })
-        }
+        {...register("description", {
+          required: "내용을 입력해주세요",
+          maxLength: {
+            value: MAX_LENGTH.description,
+            message: `게임 소개를 ${formatNumberWithCommas(MAX_LENGTH.description)}자 내로 입력해주세요`,
+          },
+        })}
+        autoComplete="off"
+        errMsg={errors.description?.message ?? ""}
       />
 
       <div className="flex gap-4 justify-end items-center">
         <p className="mb-0 text-xs">게임을 비공개로 올릴까요?</p>
-        <ThemedSwitch
-          name="isPrivate"
-          checked={formData.isPrivate}
-          onCheckedChange={() =>
-            setFormData({ ...formData, isPrivate: !formData.isPrivate })
-          }
-        />
+        <ThemedSwitch name="isPrivate" control={control} />
       </div>
     </>
   );

--- a/apps/game-builder/src/components/game/confirm/form/GameConfirmFields.tsx
+++ b/apps/game-builder/src/components/game/confirm/form/GameConfirmFields.tsx
@@ -1,20 +1,27 @@
 import Image from "next/image";
 import type { useForm } from "react-hook-form";
-import { ImageIcon, TrashIcon } from "@radix-ui/react-icons";
+import {
+  ImageIcon,
+  InfoCircledIcon,
+  Pencil1Icon,
+  TrashIcon,
+} from "@radix-ui/react-icons";
 import ThemedInputField from "@themed/ThemedInputField";
 import ThemedTextareaField from "@themed/ThemedTextareaField";
 import ThemedSwitch from "@themed/ThemedSwitch";
+import ThemedCarousel from "@themed/ThemedCarousel";
+import ThemedSelectField from "@themed/ThemedSelectField";
+import ThemedIconButton from "@themed/ThemedIconButton";
+import ThemedLabel from "@themed/ThemedLabel";
+import ThemedCard from "@themed/ThemedCard";
 import type { GameInfo } from "@/interface/customType";
 import robotIcon from "@asset/icon/robot-solid.svg";
 import { formatNumberWithCommas } from "@/utils/formatNumberWithCommas";
 import MaxLengthText, {
   setMaxLengthOptions,
 } from "@/components/common/form/MaxLengthText";
-import ThemedCarousel from "../../../theme/ui/ThemedCarousel";
-import ThemedSelectField from "../../../theme/ui/ThemedSelectField";
-import ThemedIconButton from "../../../theme/ui/ThemedIconButton";
-import ThemedLabel from "../../../theme/ui/ThemedLabel";
-import ThemedCard from "../../../theme/ui/ThemedCard";
+import TextWithCounts from "@/components/common/text/TextWithCounts";
+import DateDisplay from "@/components/common/text/DateDisplay";
 
 const MAX_LENGTH = {
   title: 50,
@@ -105,9 +112,34 @@ export default function GameConfirmFields({
         errMsg={errors.description?.message ?? ""}
       />
 
-      <div className="flex gap-4 justify-end items-center">
-        <p className="mb-0 text-xs">게임을 비공개로 올릴까요?</p>
-        <ThemedSwitch name="isPrivate" control={control} />
+      <div className="flex flex-col sm:!flex-row gap-2">
+        <div className="flex gap-2 items-center">
+          <p className="mb-0 text-xs">게임을 비공개로 올릴까요?</p>
+          <ThemedSwitch name="isPrivate" control={control} />
+        </div>
+
+        <div className="flex flex-col gap-1 flex-1 items-end min-w-[230px]">
+          <div className="text-xs flex items-center gap-2" title="작성 날짜">
+            <Pencil1Icon color="#28c362" />
+            <DateDisplay date={getValues("createdAt")} />
+          </div>
+
+          <div className="flex gap-2 flex-wrap" title="게임 상세">
+            <InfoCircledIcon color="#28c362" />
+            <TextWithCounts
+              text="페이지 수"
+              counts={getValues("counts.pages")}
+            />
+            <TextWithCounts
+              text="선택지 수"
+              counts={getValues("counts.choices")}
+            />
+            <TextWithCounts
+              text="엔딩 수"
+              counts={getValues("counts.ending")}
+            />
+          </div>
+        </div>
       </div>
     </>
   );

--- a/apps/game-builder/src/components/game/edit/GameEditDraw.tsx
+++ b/apps/game-builder/src/components/game/edit/GameEditDraw.tsx
@@ -35,7 +35,7 @@ export default function GameEditDraw({
 }: GameEditDrawProps) {
   const [isOpen, setIsOpen] = useState(false);
   const useFormProps = useForm({ defaultValues: page });
-  const { handleSubmit, reset, setValue, watch, getValues } = useFormProps;
+  const { handleSubmit, reset, control } = useFormProps;
 
   const onSubmit: SubmitHandler<PageType> = (fieldValues) => {
     updatePage(fieldValues);
@@ -67,10 +67,7 @@ export default function GameEditDraw({
 
           <GameEditFields {...useFormProps} />
 
-          <EndingPageSwitch
-            isEnding={watch("isEnding")}
-            onCheckedChange={() => setValue("isEnding", !getValues("isEnding"))}
-          />
+          <EndingPageSwitch control={control} />
 
           <DrawerFooter className="flex flex-col !px-0 mb-6">
             <ThemedButton className="w-full is-success" type="submit">

--- a/apps/game-builder/src/components/game/edit/form/EndingPageSwitch.tsx
+++ b/apps/game-builder/src/components/game/edit/form/EndingPageSwitch.tsx
@@ -1,21 +1,17 @@
 import React from "react";
+import type { Control } from "react-hook-form";
+import type { PageType } from "@/interface/customType";
 import ThemedSwitch from "@/components/theme/ui/ThemedSwitch";
 
 export default function EndingPageSwitch({
-  isEnding,
-  onCheckedChange,
+  control,
 }: {
-  isEnding: boolean;
-  onCheckedChange: () => void;
+  control: Control<PageType>;
 }) {
   return (
     <div className="flex gap-4 items-center">
       <p className="mb-0 text-sm font-bold">엔딩 페이지</p>
-      <ThemedSwitch
-        name="isPrivate"
-        checked={isEnding}
-        onCheckedChange={onCheckedChange}
-      />
+      <ThemedSwitch name="isEnding" control={control} />
     </div>
   );
 }

--- a/apps/game-builder/src/components/game/edit/form/GameEditFields.tsx
+++ b/apps/game-builder/src/components/game/edit/form/GameEditFields.tsx
@@ -3,6 +3,9 @@ import ThemedInputField from "@themed/ThemedInputField";
 import ThemedTextareaField from "@themed/ThemedTextareaField";
 import { formatNumberWithCommas } from "@/utils/formatNumberWithCommas";
 import type { PageType } from "@/interface/customType";
+import MaxLengthText, {
+  setMaxLengthOptions,
+} from "@/components/common/form/MaxLengthText";
 
 const MAX_LENGTH = {
   abridgement: 50,
@@ -18,22 +21,24 @@ export default function GameEditFields({
     watch,
   } = useFormProps;
 
-  const pageContentLen = watch("description").length || 0;
-  const pageContentLenString = formatNumberWithCommas(pageContentLen);
-  const lessThan20LeftForPageContent =
-    MAX_LENGTH.description - pageContentLen < 20;
+  const descriptioContentLen = watch("description").length || 0;
+  const descriptionMaxLengthOptions = setMaxLengthOptions(
+    descriptioContentLen,
+    MAX_LENGTH.description,
+    20
+  );
 
   return (
     <>
       <ThemedInputField
         labelText="요약"
         placeholder="페이지를 요약해보세요"
-        maxLength={50}
+        maxLength={MAX_LENGTH.abridgement}
         {...register("abridgement", {
           required: "페이지 요약을 입력해주세요",
           maxLength: {
-            value: 50,
-            message: "요약을 50자 내로 입력해주세요",
+            value: MAX_LENGTH.abridgement,
+            message: `요약을 ${MAX_LENGTH.abridgement}자 내로 입력해주세요`,
           },
         })}
         autoComplete="off"
@@ -43,16 +48,7 @@ export default function GameEditFields({
         요약은 플레이어에게 보이지 않습니다.
       </p>
 
-      <div>
-        <p
-          className={`relative h-0 top-4 px-1 text-xs text-right ${
-            lessThan20LeftForPageContent ? "text-red-500 border-red-500" : ""
-          }`}
-        >
-          {pageContentLenString} /{" "}
-          {formatNumberWithCommas(MAX_LENGTH.description)}
-        </p>
-      </div>
+      <MaxLengthText {...descriptionMaxLengthOptions} className="top-4" />
       <ThemedTextareaField
         labelText="내용"
         placeholder="페이지의 내용을 입력하세요"
@@ -62,12 +58,12 @@ export default function GameEditFields({
           required: "페이지 내용을 입력해주세요",
           maxLength: {
             value: MAX_LENGTH.description,
-            message: "페이지 내용을 3,000자 내로 입력해주세요",
+            message: `페이지 내용을 ${formatNumberWithCommas(MAX_LENGTH.description)}자 내로 입력해주세요`,
           },
         })}
         autoComplete="off"
         errMsg={errors.description?.message}
-        className={lessThan20LeftForPageContent ? "text-red-500" : ""}
+        className={descriptionMaxLengthOptions.isLessThan ? "text-red-500" : ""}
       />
     </>
   );

--- a/apps/game-builder/src/components/theme/ui/ThemedCarousel.tsx
+++ b/apps/game-builder/src/components/theme/ui/ThemedCarousel.tsx
@@ -1,3 +1,6 @@
+import { useState } from "react";
+import Image from "next/image";
+import { ImageIcon } from "@radix-ui/react-icons";
 import {
   Carousel,
   CarouselContent,
@@ -6,10 +9,14 @@ import {
   CarouselPrevious,
 } from "@repo/ui/components/ui/Carousel.tsx";
 import { AspectRatio } from "@repo/ui/components/ui/AspectRatio.tsx";
-import Image from "next/image";
 import { useThemeStore } from "@/store/useTheme";
+import type { Thumbnail } from "@/interface/customType";
 
-export default function ThemedCarousel() {
+interface ThemedCarouselProps {
+  thumbnails: Thumbnail[];
+}
+
+export default function ThemedCarousel({ thumbnails }: ThemedCarouselProps) {
   const { theme } = useThemeStore((state) => state);
   let themeClass;
 
@@ -26,36 +33,12 @@ export default function ThemedCarousel() {
   return (
     <Carousel>
       <CarouselContent className="mx-10">
-        <CarouselItem>
-          <AspectRatio ratio={16 / 9}>
-            <Image
-              src="https://picsum.photos/600/400"
-              alt="Image"
-              className="rounded-md object-cover border"
-              fill
-            />
-          </AspectRatio>
-        </CarouselItem>
-        <CarouselItem>
-          <AspectRatio ratio={16 / 9}>
-            <Image
-              src="https://picsum.photos/600/400"
-              alt="Image"
-              className="rounded-md object-cover border"
-              fill
-            />
-          </AspectRatio>
-        </CarouselItem>
-        <CarouselItem>
-          <AspectRatio ratio={16 / 9}>
-            <Image
-              src="https://picsum.photos/600/400"
-              alt="Image"
-              className="rounded-md object-cover border"
-              fill
-            />
-          </AspectRatio>
-        </CarouselItem>
+        {thumbnails.map((thumbnail) => (
+          <CarouselItemWithOnError
+            thumbnail={thumbnail}
+            key={`thumbnail-${thumbnail.id}`}
+          />
+        ))}
       </CarouselContent>
       <CarouselPrevious
         type="button"
@@ -78,5 +61,37 @@ export default function ThemedCarousel() {
         }}
       />
     </Carousel>
+  );
+}
+
+function CarouselItemWithOnError({ thumbnail }: { thumbnail: Thumbnail }) {
+  const [src, setSrc] = useState(thumbnail.url);
+  const [isError, setIsError] = useState(false);
+  const placeholderSrc =
+    "https://images.unsplash.com/photo-1588345921523-c2dcdb7f1dcd?w=800&dpr=2&q=80";
+
+  const handleError = () => {
+    setSrc(placeholderSrc);
+    setIsError(true);
+  };
+
+  return (
+    <CarouselItem>
+      <AspectRatio ratio={16 / 9}>
+        <Image
+          src={src}
+          alt="Image"
+          className="rounded-md object-cover border"
+          fill
+          onError={handleError}
+        />
+        {isError && (
+          <div className="absolute w-full h-full rounded-md border border-red-500 flex justify-center items-center">
+            <ImageIcon className="w-10 h-10" color="#aaaaaa" />
+            <div className="w-[42px] border-b-2 absolute border-[#aaaaaa] -rotate-45" />
+          </div>
+        )}
+      </AspectRatio>
+    </CarouselItem>
   );
 }

--- a/apps/game-builder/src/components/theme/ui/ThemedSelectField.tsx
+++ b/apps/game-builder/src/components/theme/ui/ThemedSelectField.tsx
@@ -1,3 +1,6 @@
+import { forwardRef } from "react";
+import type { Control } from "react-hook-form";
+import { Controller } from "react-hook-form";
 import type { InputProps } from "@repo/ui/components/ui/Input.jsx";
 import {
   Select,
@@ -7,55 +10,82 @@ import {
   SelectValue,
 } from "@repo/ui/components/ui/Select.tsx";
 import { useThemeStore } from "@/store/useTheme";
+import type { GameInfo } from "@/interface/customType";
 import { GENRES } from "@/interface/newGameData";
 import ThemedLabel from "./ThemedLabel";
 
 interface ThemedSelectFieldProps extends InputProps {
   labelText: string;
+  name: keyof GameInfo;
+  control: Control<GameInfo>;
 }
 
-export default function ThemedSelectField({
-  labelText,
-  ...props
-}: ThemedSelectFieldProps) {
-  const { theme } = useThemeStore((state) => state);
+const ThemedSelectField = forwardRef<HTMLSelectElement, ThemedSelectFieldProps>(
+  ({ labelText, name, control, ...props }, ref) => {
+    const { theme } = useThemeStore((state) => state);
 
-  if (theme === "old-game" || theme === "windows-98") {
+    if (theme === "old-game" || theme === "windows-98") {
+      return (
+        <div className="flex flex-col gap-2">
+          <ThemedLabel htmlFor={name} labelText={labelText} />
+          <div className="nes-select">
+            <Controller
+              name={name}
+              control={control}
+              defaultValue=""
+              render={({ field }) => (
+                <select
+                  {...field}
+                  id={name}
+                  value={field.value ? String(field.value) : ""}
+                  ref={ref}
+                  required
+                >
+                  <option value="" disabled hidden>
+                    {props.value}
+                  </option>
+                  {GENRES.map((genre) => (
+                    <option value={genre} key={genre}>
+                      {genre}
+                    </option>
+                  ))}
+                </select>
+              )}
+            />
+          </div>
+        </div>
+      );
+    }
+
     return (
       <div className="flex flex-col gap-2">
-        <ThemedLabel htmlFor={props.name} labelText={labelText} />
-        <div className="nes-select">
-          <select required id="default_select">
-            <option value="" disabled selected hidden>
-              {props.value}
-            </option>
-            {GENRES.map((genre) => (
-              <option value={genre} key={genre}>
-                {genre}
-              </option>
-            ))}
-          </select>
-        </div>
+        <ThemedLabel labelText={labelText} />
+        <Controller
+          name={name}
+          control={control}
+          render={({ field }) => (
+            <Select
+              onValueChange={field.onChange}
+              value={field.value ? String(field.value) : ""}
+            >
+              <SelectTrigger className="!text-xs !w-full bg-white">
+                <SelectValue placeholder={props.value} />
+              </SelectTrigger>
+              <SelectContent>
+                {GENRES.map((genre) => (
+                  <SelectItem key={genre} value={genre}>
+                    {genre}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          )}
+        />
       </div>
     );
   }
+);
 
-  return (
-    <div className="flex flex-col gap-2">
-      <ThemedLabel htmlFor={props.name} labelText={labelText} />
+ThemedSelectField.displayName = "ThemedSelectField";
 
-      <Select>
-        <SelectTrigger className="!text-xs !w-full bg-white">
-          <SelectValue placeholder={props.value} />
-        </SelectTrigger>
-        <SelectContent>
-          {GENRES.map((genre) => (
-            <SelectItem key={genre} value={genre}>
-              {genre}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
-  );
-}
+export default ThemedSelectField;

--- a/apps/game-builder/src/components/theme/ui/ThemedSwitch.tsx
+++ b/apps/game-builder/src/components/theme/ui/ThemedSwitch.tsx
@@ -1,67 +1,101 @@
+import type { Control, FieldValues, Path } from "react-hook-form";
+import { Controller } from "react-hook-form";
 import { Switch } from "@repo/ui/components/ui/Switch.tsx";
 import { useThemeStore } from "@/store/useTheme";
 
-interface SwitchProps {
-  name: string;
-  checked: boolean;
-  onCheckedChange: () => void;
+interface SwitchProps<T extends FieldValues> {
+  name: Path<T>;
+  control: Control<T>;
 }
 
-export default function ThemedSwitch({
+export default function ThemedSwitch<T extends FieldValues>({
   name,
-  checked,
-  onCheckedChange,
-}: SwitchProps) {
+  control,
+}: SwitchProps<T>) {
   const { theme } = useThemeStore((state) => state);
 
   if (theme === "windows-98") {
     return (
-      <>
-        <div>
-          <input type="radio" id={`${name}-yes`} name={name} />
-          <label htmlFor={`${name}-yes`}>네</label>
-        </div>
+      <Controller
+        name={name}
+        control={control}
+        render={({ field }) => (
+          <>
+            <div>
+              <input
+                type="radio"
+                id={`${name}-true`}
+                {...field}
+                value="true"
+                checked={field.value === "true"}
+                onChange={() => field.onChange("true")}
+              />
+              <label htmlFor={`${name}-true`}>네</label>
+            </div>
 
-        <div>
-          <input type="radio" id={`${name}-no`} name={name} />
-          <label htmlFor={`${name}-no`}>아니오</label>
-        </div>
-      </>
+            <div>
+              <input
+                type="radio"
+                id={`${name}-false`}
+                {...field}
+                value="false"
+                checked={field.value === "false"}
+                onChange={() => field.onChange("false")}
+              />
+              <label htmlFor={`${name}-false`}>아니오</label>
+            </div>
+          </>
+        )}
+      />
     );
   }
 
   if (theme === "old-game") {
     return (
-      <>
-        <label className="text-sm font-bold mb-0">
-          <input
-            type="radio"
-            className="nes-radio"
-            name={name}
-            defaultChecked={checked}
-          />
-          <span>네</span>
-        </label>
+      <Controller
+        name={name}
+        control={control}
+        render={({ field }) => (
+          <>
+            <label className="text-sm font-bold mb-0">
+              <input
+                type="radio"
+                className="nes-radio"
+                {...field}
+                value="true"
+                checked={field.value === "true"}
+                onChange={() => field.onChange("true")}
+              />
+              <span>네</span>
+            </label>
 
-        <label className="text-sm font-bold mb-0">
-          <input
-            type="radio"
-            className="nes-radio"
-            name={name}
-            defaultChecked={!checked}
-          />
-          <span>아니오</span>
-        </label>
-      </>
+            <label className="text-sm font-bold mb-0">
+              <input
+                type="radio"
+                className="nes-radio"
+                {...field}
+                value="false"
+                checked={field.value === "false"}
+                onChange={() => field.onChange("false")}
+              />
+              <span>아니오</span>
+            </label>
+          </>
+        )}
+      />
     );
   }
 
   return (
-    <Switch
-      id={name}
+    <Controller
+      control={control}
       name={name}
-      checked={checked}
-      onCheckedChange={onCheckedChange}
+      render={({ field }) => (
+        <Switch
+          checked={Boolean(field.value)}
+          onCheckedChange={field.onChange}
+        />
+      )}
     />
   );
 }

--- a/apps/game-builder/src/hooks/useGameData.tsx
+++ b/apps/game-builder/src/hooks/useGameData.tsx
@@ -5,7 +5,7 @@ import type { ExtendsCreateGameResDto } from "@/interface/newGameData";
 import type {
   ChoiceType,
   GameBuild,
-  GameType,
+  GameBuildType,
   PageType,
 } from "@/interface/customType";
 
@@ -14,7 +14,7 @@ const tempIsEnding = false;
 const setGameWithSource = (
   gameData: GameBuild,
   source: PageType["source"]
-): GameType => {
+): GameBuildType => {
   const pagesWithTag = gameData.pages.map((page) => {
     const choicesWithTag = page.choices.map((choice) => ({
       ...choice,
@@ -33,7 +33,9 @@ const setGameWithSource = (
     ...gameData,
     pages: pagesWithTag,
     source,
-  } as GameType;
+    description: "",
+    isPrivate: false,
+  } as GameBuildType;
 };
 
 export default function useGameData({
@@ -43,7 +45,8 @@ export default function useGameData({
   createdGame: ExtendsCreateGameResDto | null;
   gameBuildData: GameBuild;
 }) {
-  const newGame: GameType | null = createdGame && new NewGameBuild(createdGame);
+  const newGame: GameBuildType | null =
+    createdGame && new NewGameBuild(createdGame);
   const game = setGameWithSource(gameBuildData, "server");
   const [gamePageList, setGamePageList] = useState(
     newGame?.pages ?? game.pages

--- a/apps/game-builder/src/interface/customType.ts
+++ b/apps/game-builder/src/interface/customType.ts
@@ -2,20 +2,26 @@ import type { GetAllGameResDto } from "@choosetale/nestia-type/lib/structures/Ge
 import type { Choice } from "@choosetale/nestia-type/lib/structures/Choice";
 import type { Page } from "@choosetale/nestia-type/lib/structures/Page";
 import type { UpdateGameReqDto } from "@choosetale/nestia-type/lib/structures/UpdateGameReqDto";
+import type { Genres } from "@choosetale/nestia-type/lib/structures/Genres";
 
-interface Thumbnail {
+export interface Thumbnail {
   id: number;
   url: string;
 }
+
 export interface GameInfo extends UpdateGameReqDto {
   id: number;
+  title: string;
+  description: string;
+  isPrivate: boolean;
+  genre: Genres;
+  thumbnails: Thumbnail[];
+  createdAt: string;
   counts: {
     pages: number;
     choices: number;
     ending: number;
   };
-  thumbnails: Thumbnail[];
-  createdAt: string;
 }
 export type GameBuild = GetAllGameResDto;
 
@@ -34,10 +40,16 @@ interface BasePage extends Page {
 
 export type PageType = BasePage & { source: "server" | "client" };
 export type ChoiceType = BaseChoice & { source: "server" | "client" };
-export interface GameType {
+export interface GameBuildType {
   id: number;
   title: string;
   pages: PageType[];
+}
+export interface GameType {
+  id: number;
+  title: string;
+  description: string;
+  isPrivate: boolean;
 }
 
 export interface LinkedPage {

--- a/apps/game-builder/src/interface/newGameData.ts
+++ b/apps/game-builder/src/interface/newGameData.ts
@@ -31,15 +31,20 @@ export interface ExtendsCreateGameResDto extends CreateGameResDto {
     content: string;
     abridgement: string;
   };
+  isPrivate: boolean;
 }
 export class NewGameBuild {
   id: number;
   title: string;
   pages: PageType[];
+  isPrivate: boolean;
+  description: string;
 
   constructor(props: ExtendsCreateGameResDto) {
     this.id = props.id;
     this.title = "";
+    this.description = "";
+    this.isPrivate = false;
     this.pages = [
       {
         ...props.page,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,6 +32,9 @@ importers:
       '@tailwindcss/line-clamp':
         specifier: ^0.4.4
         version: 0.4.4(tailwindcss@3.4.1)
+      date-fns:
+        specifier: ^3.6.0
+        version: 3.6.0
       framer-motion:
         specifier: ^11.3.2
         version: 11.3.2(react-dom@18.2.0)(react@18.2.0)
@@ -2559,6 +2562,10 @@ packages:
   /damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
     dev: true
+
+  /date-fns@3.6.0:
+    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
+    dev: false
 
   /debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}


### PR DESCRIPTION

### 데이터 연결
![image](https://github.com/user-attachments/assets/43a48a92-9449-4561-ac50-e0fa766df660)
- [x] 데이터 출력: `/confirm` 페이지 Form 데이터 연결
- [x] 컴포넌트 수정: select과 switch 컴포넌트에 React Hook Form Controller 적용
- [x] 타입: api 응답에 맞게 GameInfo 타입 적용, Themed Switch 컴포넌트에 제네릭 타입 적용

### UI 개선
- [x] 컴포넌트 개선: Thumbnail 이미지 onError 핸들링 추가
![image](https://github.com/user-attachments/assets/0e2f7048-1cb8-4b37-9af4-4b61c1a8cca7)
- [x] 컴포넌트 추가: counts 데이터 출력할 컴포넌트 추가
![image](https://github.com/user-attachments/assets/07b9cc7a-2be5-4e04-9ea8-a346cb43be6a)
