### PR TITLE
feat(S1): 페이지 수정 날짜 상대적 표기

### DIFF
--- a/apps/game-builder/package.json
+++ b/apps/game-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "game-builder",
-  "version": "0.0.3",
+  "version": "0.0.31",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3001",

--- a/apps/game-builder/src/components/card/page/PageCard.tsx
+++ b/apps/game-builder/src/components/card/page/PageCard.tsx
@@ -1,5 +1,9 @@
 import Image from "next/image";
-import { CardStackPlusIcon, TrashIcon } from "@radix-ui/react-icons";
+import {
+  CardStackPlusIcon,
+  StopwatchIcon,
+  TrashIcon,
+} from "@radix-ui/react-icons";
 import {
   CardContent,
   CardDescription,
@@ -7,11 +11,12 @@ import {
   CardTitle,
 } from "@repo/ui/components/ui/Card.tsx";
 import type { PageType } from "@/interface/customType";
+import type useGameData from "@/hooks/useGameData";
 import ThemedCard from "@themed/ThemedCard";
 import ThemedIconButton from "@themed/ThemedIconButton";
 import robotIcon from "@asset/icon/robot-solid.svg";
 import GameEditDraw from "@/components/game/edit/GameEditDraw";
-import type useGameData from "@/hooks/useGameData";
+import DateDisplayRelative from "@/components/common/text/DateDisplayRelative";
 import DotIndicator from "./DotIndicator";
 
 interface PageCardProps {
@@ -71,6 +76,10 @@ export default function PageCard({
               </ThemedIconButton>
             </>
           )}
+          <div className="absolute bottom-3 right-3 text-xs mt-2 opacity-50 flex items-center gap-1">
+            <StopwatchIcon className="w-3 h-3" />
+            <DateDisplayRelative date={page.updatedAt} />
+          </div>
         </CardFooter>
 
         <GameEditDraw page={page} updatePage={updatePage} />

--- a/apps/game-builder/src/components/common/text/DateDisplayRelative.tsx
+++ b/apps/game-builder/src/components/common/text/DateDisplayRelative.tsx
@@ -1,0 +1,12 @@
+import { formatDistanceToNow } from "date-fns";
+import { ko } from "date-fns/locale";
+
+export default function DateDisplayRelative({ date }: { date: string }) {
+  const parsedDate = new Date(date);
+  const formattedDate = formatDistanceToNow(parsedDate, {
+    addSuffix: true,
+    locale: ko,
+  });
+
+  return <>{formattedDate}</>;
+}


### PR DESCRIPTION
### 추가 기능
- 날짜 표기
![image](https://github.com/user-attachments/assets/5add3c01-6d39-44d0-9d42-51d45604c484)
![image](https://github.com/user-attachments/assets/b0d2f0bf-a87c-46cd-b56d-9882711bb531)
![image](https://github.com/user-attachments/assets/b5020cc9-6602-4c15-9aba-2fb5580356a8)

- 해당 컴포넌트 추가
```tsx
import { formatDistanceToNow } from "date-fns";
import { ko } from "date-fns/locale";

export default function DateDisplayRelative({ date }: { date: string }) {
  const parsedDate = new Date(date);
  const formattedDate = formatDistanceToNow(parsedDate, {
    addSuffix: true,
    locale: ko,
  });

  return <>{formattedDate}</>;
}
```

### 프로젝트 내 날짜 출력 컴포넌트
- DateDisplay는 날짜와 원하는 formatStr를 props로 전달해서, 원하는 형태의 dateString을 출력합니다. ex) yyyy-MM-dd
- DateDisplayRelative는 날짜를 props로 전달해서, 지금으로부터의 상대적인 dateString을 출력합니다.