### PR TITLE
fix(S1): 썸네일 업로드 오류 수정, 타입 조정

### DIFF
--- a/apps/game-builder/src/actions/choice/getRecommendChoice.ts
+++ b/apps/game-builder/src/actions/choice/getRecommendChoice.ts
@@ -3,12 +3,18 @@ import type { HttpError } from "@choosetale/nestia-type";
 import { API_URL } from "@/config/config";
 import type { ApiResponse, SuccessResponse } from "../action";
 
+interface Choice {
+  title: string;
+  description: string;
+}
+
+interface SocketMessage {
+  message: Choice[];
+}
+
 // --게임 정보 불러오기--
 interface GetRecommendChoiceSuccessResponse extends SuccessResponse {
-  choices: {
-    title: string;
-    description: string;
-  }[];
+  choices: Choice[];
 }
 
 export const getRecommendChoice = async (
@@ -26,7 +32,7 @@ export const getRecommendChoice = async (
       }
     );
 
-    const data = await response.json();
+    const data = (await response.json()) as SocketMessage;
     return { success: true, choices: data.message };
   } catch (error) {
     return { success: false, error: error as HttpError };

--- a/apps/game-builder/src/actions/thumbnail/uploadThumbnail.ts
+++ b/apps/game-builder/src/actions/thumbnail/uploadThumbnail.ts
@@ -3,14 +3,16 @@ import type { HttpError } from "@choosetale/nestia-type";
 import { API_URL } from "@/config/config";
 import type { ApiResponse, SuccessResponse } from "../action";
 
+interface UploadThumbnail {
+  id: number;
+  url: string;
+  gameId: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 interface UploadThumbnailSuccessResponse extends SuccessResponse {
-  uploadedThumbnail: {
-    id: number;
-    url: string;
-    gameId: number;
-    createdAt: string;
-    updatedAt: string;
-  }[];
+  uploadedThumbnail: UploadThumbnail;
 }
 export const uploadThumbnail = async (
   gameId: number,
@@ -27,8 +29,12 @@ export const uploadThumbnail = async (
       throw new Error(errorData.message || "Failed to upload thumbnails");
     }
 
-    const uploadedThumbnail = await response.json();
-    return { success: true, uploadedThumbnail };
+    const data = (await response.json()) as UploadThumbnail[];
+    if (!data) {
+      throw new Error("Failed to upload thumbnails");
+    }
+
+    return { success: true, uploadedThumbnail: data[0] };
   } catch (error) {
     return { success: false, error: error as HttpError };
   }

--- a/apps/game-builder/src/hooks/useThumbnail.ts
+++ b/apps/game-builder/src/hooks/useThumbnail.ts
@@ -25,7 +25,7 @@ export default function useThumbnail({
         const currentThumbnails = getValues("thumbnails") || [];
         setValue("thumbnails", [
           ...currentThumbnails,
-          ...response.uploadedThumbnail,
+          response.uploadedThumbnail,
         ]);
 
         setTimeout(() => {


### PR DESCRIPTION
### 썸네일 업로드 시 발생하는 오류 수정
- 유저가 썸네일을 업로드했을 때, response의 형태가 맞지 않아 오류 발생
- 오류 발생 위치: 서버 컴포넌트에서 클라이언트 컴포넌트로 response를 보낼 때 발생
### 타입 수정
-  eslint 오류로 인해, 타입 수정