### PR TITLE
fix(S1): 선택지 업데이트 후 게임 리로드

### DIFF
--- a/apps/game-builder/src/components/card/choice/LinkedPageIndicator.tsx
+++ b/apps/game-builder/src/components/card/choice/LinkedPageIndicator.tsx
@@ -15,7 +15,7 @@ export default function LinkedPageIndicator({
       type="button"
     >
       <div className="flex items-center px-2 py-1">
-        <Link1Icon className="h-4 w-4" color="#24c45d" />
+        <Link1Icon className="shrink-0 h-4 w-4" color="#24c45d" />
         <p className="px-1 text-xs text-green-500 overflow-hidden whitespace-nowrap overflow-ellipsis">
           {linkedPage?.content}
         </p>

--- a/apps/game-builder/src/components/card/page/PageCard.tsx
+++ b/apps/game-builder/src/components/card/page/PageCard.tsx
@@ -51,7 +51,11 @@ export default function PageCard({
             <CardTitle
               className={`mb-2 !text-[16px] break-all ${showChoiceButtons ? "" : "pr-6"}`}
             >
-              {abridgement}
+              {abridgement !== "" ? (
+                abridgement
+              ) : (
+                <span className="opacity-20">요약이 없습니다</span>
+              )}
             </CardTitle>
             <CardDescription className="text-xs line-clamp-4 mb-0 break-all">
               {description}

--- a/apps/game-builder/src/components/game/builder/GameBuilderContent.tsx
+++ b/apps/game-builder/src/components/game/builder/GameBuilderContent.tsx
@@ -26,6 +26,7 @@ export default function GameBuilderContent({
     updateChoicesData,
     deleteChoiceData,
     deletePageData,
+    reloadGameData,
   } = useGameDataProps;
   const {
     unFixedChoicesMap,
@@ -66,6 +67,7 @@ export default function GameBuilderContent({
     if (choice.source === "server") {
       updateChoicesData(gameId, choice.id, payload);
     }
+    reloadGameData();
   };
   const handleDeleteChoice = (pageId: number, choice: ChoiceType) => {
     if (choice.source === "client") removeUnFixedChoice(pageId, choice.id);

--- a/apps/game-builder/src/hooks/useGameData.ts
+++ b/apps/game-builder/src/hooks/useGameData.ts
@@ -9,6 +9,7 @@ import type {
   NewChoice,
   PageType,
 } from "@/interface/customType";
+import { getGameAllById } from "@/actions/game/getGame";
 import { createPage } from "@/actions/page/createPage";
 import { updatePage } from "@/actions/page/updatePage";
 import { deletePage } from "@/actions/page/deletePage";
@@ -55,6 +56,7 @@ export default function useGameData({
   const [gamePageList, setGamePageList] = useState(
     newGame?.pages ?? game.pages
   );
+  const gameId = game.id;
 
   const addPageData = async ({
     depth,
@@ -198,6 +200,14 @@ export default function useGameData({
     }
   };
 
+  const reloadGameData = async () => {
+    const gameAllResponse = await getGameAllById(gameId);
+    if (gameAllResponse.success) {
+      const gameData = setGameWithSource(gameAllResponse.gameAll, "server");
+      setGamePageList(gameData.pages);
+    }
+  };
+
   return {
     gamePageList,
     addPageData,
@@ -206,5 +216,6 @@ export default function useGameData({
     addChoiceData,
     updateChoicesData,
     deleteChoiceData,
+    reloadGameData,
   };
 }


### PR DESCRIPTION
## 선택지 업데이트 후 게임 리로드
- 상세 내용 이슈 링크: https://github.com/ChooseTale/Frontend/issues/89#issuecomment-2304418997
- 업데이트 조건: 선택지를 추가/수정할 때 업데이트
- 업데이트 방식: 전체 게임 데이터를 리패칭하여 업데이트한다.

---

### 마이너 UI 업데이트
- 링크 아이콘 사라지지 않도록 shrink-0 추가
![image](https://github.com/user-attachments/assets/43cd2a10-387f-41d0-916f-9ddea3071119)
- "요약이 없습니다" 추가
![image](https://github.com/user-attachments/assets/2d9b3b9a-3c4c-49e6-baff-095b7f370ade)
