### PR TITLE
fix(S1): get game api 성공 응답의 에러 객체 처리

### DIFF
--- a/apps/game-builder/src/actions/game/getGame.ts
+++ b/apps/game-builder/src/actions/game/getGame.ts
@@ -2,7 +2,7 @@
 import type { HttpError } from "@choosetale/nestia-type";
 import type { GetAllGameResDto as GetGameAllResDto } from "@choosetale/nestia-type/lib/structures/GetAllGameResDto";
 import { API_URL } from "@/config/config";
-import type { GameInfo } from "@/interface/customType";
+import type { ApiErrorResponse, GameInfo } from "@/interface/customType";
 import type { ApiResponse, SuccessResponse } from "../action";
 
 // --게임 정보 불러오기--
@@ -46,7 +46,14 @@ export const getGameAllById = async (
       mode: "no-cors",
     });
 
-    const gameAll = (await response.json()) as GetGameAllResDto;
+    const gameAll = (await response.json()) as
+      | ApiErrorResponse
+      | GetGameAllResDto;
+
+    if ("statusCode" in gameAll) {
+      return { success: false, error: new Error(gameAll.message) };
+    }
+
     return { success: true, gameAll };
   } catch (error) {
     return { success: false, error: error as HttpError };

--- a/apps/game-builder/src/hooks/useGameData.ts
+++ b/apps/game-builder/src/hooks/useGameData.ts
@@ -17,32 +17,6 @@ import { createChoice } from "@/actions/choice/createChoice";
 import { updateChoice } from "@/actions/choice/updateChoice";
 import { deleteChoice } from "@/actions/choice/deleteChoice";
 
-const setGameWithSource = (
-  gameData: GameBuild,
-  source: PageType["source"]
-): GameBuildType => {
-  const pagesWithTag = gameData.pages.map((page) => {
-    const choicesWithTag = page.choices.map((choice) => ({
-      ...choice,
-      source,
-    })) as ChoiceType[];
-
-    return {
-      ...page,
-      choices: choicesWithTag,
-      source,
-    } as PageType;
-  });
-
-  return {
-    ...gameData,
-    pages: pagesWithTag,
-    source,
-    description: "",
-    isPrivate: false,
-  } as GameBuildType;
-};
-
 export default function useGameData({
   createdGame,
   gameBuildData,
@@ -50,6 +24,33 @@ export default function useGameData({
   createdGame: ExtendsCreateGameResDto | null;
   gameBuildData: GameBuild;
 }) {
+  const setGameWithSource = (
+    gameData: GameBuild,
+    source: PageType["source"]
+  ): GameBuildType => {
+    if (!gameData) throw new Error("gameData is required");
+    const pagesWithTag = gameData.pages?.map((page) => {
+      const choicesWithTag = page.choices?.map((choice) => ({
+        ...choice,
+        source,
+      })) as ChoiceType[];
+
+      return {
+        ...page,
+        choices: choicesWithTag,
+        source,
+      } as PageType;
+    });
+
+    return {
+      ...gameData,
+      pages: pagesWithTag,
+      source,
+      description: "",
+      isPrivate: false,
+    } as GameBuildType;
+  };
+
   const newGame: GameBuildType | null =
     createdGame && new NewGameBuild(createdGame);
   const game = setGameWithSource(gameBuildData, "server");

--- a/apps/game-builder/src/interface/customType.ts
+++ b/apps/game-builder/src/interface/customType.ts
@@ -4,6 +4,12 @@ import type { Page } from "@choosetale/nestia-type/lib/structures/Page";
 import type { UpdateGameReqDto } from "@choosetale/nestia-type/lib/structures/UpdateGameReqDto";
 import type { Genres } from "@choosetale/nestia-type/lib/structures/Genres";
 
+export interface ApiErrorResponse {
+  statusCode: number;
+  message: string;
+  error: string;
+}
+
 export interface Thumbnail {
   id: number;
   url: string;


### PR DESCRIPTION
### 내용
- HttpError 응답이 아닌, response에 에러 형태의 객체가 오는 경우 처리

### 발생했던 에러
- 에러가 아닌 것으로 분기되어 클라이언트에서 데이터를 처리하려 함
- **클라이언트에서 에러가 발생**해서 `공통 에러 페이지`로 넘어감 (500에러 페이지)
- 👉 에러가 객체 형태의 응답인 경우를 처리해야 함

### 수정 사항
- 타입 추가
```tsx
export interface ApiErrorResponse {
  statusCode: number;
  message: string;
  error: string;
}
```
- action 수정
```tsx
export const getGameAllById = async (
  gameId: number
): Promise<ApiResponse<GetGameAllSuccessResponse>> => {
  try {
    const response = await fetch(`${API_URL}/game/${gameId}`, {
      method: "GET",
      headers: {
        "Content-Type": "application/json",
      },
      mode: "no-cors",
    });

    const gameAll = (await response.json()) as
      | ApiErrorResponse  // ✅ 추가한 에러 타입
      | GetGameAllResDto;

    if ("statusCode" in gameAll) { // ✅ 추가한 에러 응답 핸들링
      return { success: false, error: new Error(gameAll.message) };
    }

    return { success: true, gameAll };
  } catch (error) {
    return { success: false, error: error as HttpError };
  }
```
- page 컴포넌트에서 404 페이지로 리디렉션하는 분기가 실행되도록 함
![image](https://github.com/user-attachments/assets/ea7df778-3485-49d0-8799-2920c800aece)
