### PR TITLE
fix(S1): 선택지, 페이지 추가 동작 오류 수정

### DIFF
--- a/apps/game-builder/src/components/card/choice/StaticChoice.tsx
+++ b/apps/game-builder/src/components/card/choice/StaticChoice.tsx
@@ -10,6 +10,7 @@ import ThemedCard from "@/components/theme/ui/ThemedCard";
 import ThemedIconButton from "@/components/theme/ui/ThemedIconButton";
 import DotIndicator from "./DotIndicator";
 import LinkedPageIndicator from "./LinkedPageIndicator";
+import UnLinkedPageIndicator from "./UnLinkedPageIndicator";
 
 export function StaticChoice({
   title = "title 없음",
@@ -35,11 +36,13 @@ export function StaticChoice({
     <div className="pt-4">
       <ThemedCard className="relative min-h-24 !ml-12 mb-7" isChoice>
         <DotIndicator isChoosen />
-        {linkedPage && (
+        {linkedPage ? (
           <LinkedPageIndicator
             onClick={() => scrollToPage(linkedPage.pageId)}
             linkedPage={linkedPage}
           />
+        ) : (
+          <UnLinkedPageIndicator />
         )}
 
         <div className="flex-1">

--- a/apps/game-builder/src/components/card/choice/UnLinkedPageIndicator.tsx
+++ b/apps/game-builder/src/components/card/choice/UnLinkedPageIndicator.tsx
@@ -1,0 +1,17 @@
+import { Link1Icon } from "@radix-ui/react-icons";
+
+export default function UnLinkedPageIndicator() {
+  return (
+    <button
+      className="w-full absolute -bottom-1 translate-y-full rounded-lg shadow-sm border border-red-400 text-card-foreground cursor-auto"
+      type="button"
+    >
+      <div className="flex items-center px-2 py-1">
+        <Link1Icon className="shrink-0 h-4 w-4" color="#ef4444" />
+        <p className="px-1 text-xs text-red-400 overflow-hidden whitespace-nowrap overflow-ellipsis">
+          연결되지 않은 페이지
+        </p>
+      </div>
+    </button>
+  );
+}

--- a/apps/game-builder/src/components/card/page/PageCard.tsx
+++ b/apps/game-builder/src/components/card/page/PageCard.tsx
@@ -1,6 +1,7 @@
 import Image from "next/image";
 import {
   CardStackPlusIcon,
+  ReloadIcon,
   StopwatchIcon,
   TrashIcon,
 } from "@radix-ui/react-icons";
@@ -64,20 +65,30 @@ export default function PageCard({
         </div>
 
         <CardFooter
-          className={`flex items-center p-0 pt-2 gap-1 ${isGenerating ? "pointer-events-none cursor-default animate-pulse duration-1000" : ""} ${isEnding ? "flex-col justify-center items-end" : ""}`}
+          className={`flex items-center p-0 pt-2 gap-1 ${isEnding ? "flex-col justify-center items-end" : ""}`}
         >
           {showChoiceButtons && (
             <>
               <ThemedIconButton onClick={addChoice}>
                 <CardStackPlusIcon className="h-8 w-8" />
               </ThemedIconButton>
-              <ThemedIconButton onClick={genAIChoice}>
-                <Image
-                  className="h-8 w-8 -translate-y-[2px]"
-                  src={robotIcon}
-                  alt="generate choice"
-                />
-              </ThemedIconButton>
+              <div
+                className={`min-w-[40px] ${isGenerating ? "pointer-events-none cursor-default animate-pulse duration-1000" : ""}`}
+              >
+                {isGenerating ? (
+                  <ThemedIconButton onClick={genAIChoice}>
+                    <ReloadIcon className="h-6 w-6 animate-spin" />
+                  </ThemedIconButton>
+                ) : (
+                  <ThemedIconButton onClick={genAIChoice}>
+                    <Image
+                      className="h-8 w-8 -translate-y-[2px]"
+                      src={robotIcon}
+                      alt="generate choice"
+                    />
+                  </ThemedIconButton>
+                )}
+              </div>
             </>
           )}
 

--- a/apps/game-builder/src/components/game/builder/GameBuilderContent.tsx
+++ b/apps/game-builder/src/components/game/builder/GameBuilderContent.tsx
@@ -74,8 +74,7 @@ export default function GameBuilderContent({
     if (choice.source === "server") deleteChoiceData(pageId, choice.id);
   };
   const handleDeletePage = (pageId: number) => {
-    if (confirm("페이지를 삭제하면 페이지의 선택지가 함께 삭제됩니다."))
-      deletePageData(pageId);
+    if (confirm("페이지를 삭제합니다.")) deletePageData(pageId);
   };
 
   const availablePages = gamePageList.map((page) => ({
@@ -137,14 +136,19 @@ export default function GameBuilderContent({
                     isGenerating={isGenerating}
                   />
                   {combinedChoices
-                    .sort((a, b) => a.id - b.id)
+                    .sort((a, b) => {
+                      if (a.id >= 0 && b.id >= 0) return a.id - b.id;
+                      if (a.id >= 0 && b.id < 0) return -1;
+                      if (a.id < 0 && b.id >= 0) return 1;
+                      return a.id - b.id;
+                    })
                     .map((choice) => {
                       return (
                         <ChoiceCard
                           key={`${choice.source}-page${page.id}-choice${choice.id}`}
                           choice={choice}
                           defaultFixed={choice.source === "server"}
-                          fixChoice={(partialChoice) =>
+                          handleFixChoice={(partialChoice) =>
                             handleFixChoice(page.id, partialChoice)
                           }
                           removeChoice={() =>
@@ -152,7 +156,7 @@ export default function GameBuilderContent({
                           }
                           availablePages={availablePages}
                           linkedPage={getLinkedPage(choice.toPageId)}
-                          handleNewPage={handleNewPage}
+                          addPageData={addPageData}
                         />
                       );
                     })}

--- a/apps/game-builder/src/components/game/builder/newPage/NewPageModal.tsx
+++ b/apps/game-builder/src/components/game/builder/newPage/NewPageModal.tsx
@@ -1,12 +1,14 @@
 import type { Dispatch, SetStateAction } from "react";
-import { type SubmitHandler, useForm } from "react-hook-form";
+import { useForm } from "react-hook-form";
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
   DialogFooter,
+  DialogDescription,
 } from "@repo/ui/components/ui/Dialog.tsx";
+import type { NewPage } from "@/interface/customType";
 import { formatNumberWithCommas } from "@/utils/formatNumberWithCommas";
 import ThemedButton from "@/components/theme/ui/ThemedButton";
 import ThemedTextareaField from "@/components/theme/ui/ThemedTextareaField";
@@ -14,7 +16,6 @@ import ThemedSwitch from "@/components/theme/ui/ThemedSwitch";
 import MaxLengthText, {
   setMaxLengthOptions,
 } from "@/components/common/form/MaxLengthText";
-import type { NewPage } from "@/interface/customType";
 
 interface NewPageModalProps extends ReturnType<typeof useForm<NewPage>> {
   handleNewPage: (newPageData: { content: string; isEnding: boolean }) => void;
@@ -36,23 +37,24 @@ export default function NewPageModal({
     isEnding: false,
   };
   const {
-    handleSubmit,
     register,
     watch,
     reset,
     formState: { errors },
     control,
+    trigger,
+    getValues,
   } = useForm({
     defaultValues,
   });
 
-  const onSubmit: SubmitHandler<typeof defaultValues> = (
-    fieldValues,
-    event
-  ) => {
-    event?.stopPropagation();
-    handleNewPage(fieldValues);
-    onClose();
+  const handleButtonClick = async () => {
+    const isValid = await trigger();
+    if (isValid) {
+      const fieldValues = getValues();
+      handleNewPage(fieldValues);
+      onClose();
+    }
   };
 
   const onClose = () => {
@@ -69,11 +71,12 @@ export default function NewPageModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent aria-describedby="add new page">
+      <DialogContent>
         <DialogHeader>
           <DialogTitle>새 페이지</DialogTitle>
+          <DialogDescription />
         </DialogHeader>
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form className="space-y-4">
           <div>
             <MaxLengthText {...contentMaxLengthOptions} className="top-0" />
             <ThemedTextareaField
@@ -104,7 +107,9 @@ export default function NewPageModal({
                 엔딩 페이지
               </p>
             </div>
-            <ThemedButton type="submit">추가</ThemedButton>
+            <ThemedButton type="button" onClick={handleButtonClick}>
+              추가
+            </ThemedButton>
             <ThemedButton type="button" variant="ghost" onClick={onClose}>
               취소
             </ThemedButton>

--- a/apps/game-builder/src/hooks/useGameData.ts
+++ b/apps/game-builder/src/hooks/useGameData.ts
@@ -123,6 +123,7 @@ export default function useGameData({
   };
 
   const addChoiceData = async (pageId: number, choice: NewChoice) => {
+    if (choice.childPageId < 0) throw new Error("Child page id is required");
     const result = await createChoice(gameBuildData.id, choice);
 
     if (result.success) {


### PR DESCRIPTION
> [!Note]
> **Ensure Proper Form Isolation**: Form을 올바르게 캡슐화 할 것

## 페이지 생성 시, 동작 오류
- 모달 내 "추가" 버튼을 클릭 시, 모달 내의 form submit 이벤트가 상위 form에 전달되는 점
- 기존 작성된 코드에서 하위 폼의 event에 stopPropagation 메소드가 존재하고, 실행했지만 이벤트 전파가 차단되지 않음

![image](https://github.com/user-attachments/assets/c93afd4d-cb8b-4ce3-9a88-2e8b65c2bd73)
- 해결 필요성
  - 선택한 페이지가 없는 상태에서 새 페이지를 선택하는 경우는 상위 form의 OnSubmit에서 확인하고 얼리리턴으로 막을 수 있지만 (toPageId가 양수임을 확인), select에 이미 생성된 페이지가 선택되어 있는 상태에서 새 페이지를 생성하면, 페이지를 생성할 때 선택지 또한 이전 선택한 페이지 기준으로 선택지 생성 요청을 보내기 때문에 잘못된 선택지를 만들게 되어 잘못된 요청을 보내게 됩니다.

## 선택지 추가 시, 동작 오류
- 선택지의 toPageId가 음수인 경우의 예외 처리를 추가
- response 객체의 statusCode가 404인 경우 추가

## NewPageModal form의 버튼 동작 변경
- 모달창 내부의 form 때문에 문제가 생기기 때문에 버튼의 동작을 submit에서 button으로 바꾸고, onSubmit 이벤트를 onClick 이벤트로 변경했습니다.
   - react-hook-form의 trigger 메소드를 사용하면 유효성 검사를 기존과 동일하게 진행할 수 있습니다.
```tsx
const handleButtonClick = async () => {
  const isValid = await trigger();
  if (isValid) {
    const fieldValues = getValues();
    handleNewPage(fieldValues);
    onClose();
  }
};
```
