### PR TITLE
refactor(S1): 캐시 revalidate

### DIFF
--- a/apps/game-builder/package.json
+++ b/apps/game-builder/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@repo/game-builder",
-  "version": "0.0.6",
+  "version": "0.0.62",
   "scripts": {
     "dev": "next dev -p 3001",
     "build": "next build",

--- a/apps/game-builder/src/actions/choice/createChoice.ts
+++ b/apps/game-builder/src/actions/choice/createChoice.ts
@@ -1,4 +1,5 @@
 "use server";
+import { revalidateTag } from "next/cache";
 import type { HttpError } from "@choosetale/nestia-type";
 import type { CreateChoiceResDto } from "@choosetale/nestia-type/lib/structures/CreateChoiceResDto";
 import type { ApiErrorResponse, NewChoice } from "@/interface/customType";
@@ -32,6 +33,7 @@ export const createChoice = async (
       throw new Error(choiceRes.message);
     }
 
+    revalidateTag("game-all");
     return { success: true, choice: choiceRes };
   } catch (error) {
     return { success: false, error: error as HttpError };

--- a/apps/game-builder/src/actions/choice/deleteChoice.ts
+++ b/apps/game-builder/src/actions/choice/deleteChoice.ts
@@ -1,4 +1,5 @@
 "use server";
+import { revalidateTag } from "next/cache";
 import type { HttpError } from "@choosetale/nestia-type";
 import { API_URL } from "@/config/config";
 
@@ -11,6 +12,7 @@ export const deleteChoice = async (gameId: number, choiceId: number) => {
       },
     });
 
+    revalidateTag("game-all");
     return { success: true };
   } catch (error) {
     return { success: false, error: error as HttpError };

--- a/apps/game-builder/src/actions/choice/getRecommendChoice.ts
+++ b/apps/game-builder/src/actions/choice/getRecommendChoice.ts
@@ -1,4 +1,5 @@
 "use server";
+import { revalidateTag } from "next/cache";
 import type { HttpError } from "@choosetale/nestia-type";
 import { API_URL } from "@/config/config";
 import type { ApiResponse, SuccessResponse } from "../action";
@@ -32,6 +33,7 @@ export const getRecommendChoice = async (
       }
     );
 
+    revalidateTag("game-all");
     const data = (await response.json()) as SocketMessage;
     return { success: true, choices: data.message };
   } catch (error) {

--- a/apps/game-builder/src/actions/choice/updateChoice.ts
+++ b/apps/game-builder/src/actions/choice/updateChoice.ts
@@ -1,4 +1,5 @@
 "use server";
+import { revalidateTag } from "next/cache";
 import type { HttpError } from "@choosetale/nestia-type";
 import type { UpdateChoiceResDto } from "@choosetale/nestia-type/lib/structures/UpdateChoiceResDto";
 import type { NewChoice } from "@/interface/customType";
@@ -28,6 +29,7 @@ export const updateChoice = async (
 
     const choice = (await response.json()) as UpdateChoiceResDto;
 
+    revalidateTag("game-all");
     return { success: true, choice };
   } catch (error) {
     return { success: false, error: error as HttpError };

--- a/apps/game-builder/src/actions/game/getGame.ts
+++ b/apps/game-builder/src/actions/game/getGame.ts
@@ -20,6 +20,7 @@ export const getGameInfoById = async (
         "Content-Type": "application/json",
       },
       mode: "no-cors",
+      next: { tags: ["game", "game-info"] },
     });
 
     const gameInfo = (await response.json()) as GameInfo;
@@ -44,6 +45,7 @@ export const getGameAllById = async (
         "Content-Type": "application/json",
       },
       mode: "no-cors",
+      next: { tags: ["game", "game-all"] },
     });
 
     const gameAll = (await response.json()) as

--- a/apps/game-builder/src/actions/game/updateGame.ts
+++ b/apps/game-builder/src/actions/game/updateGame.ts
@@ -1,4 +1,5 @@
 "use server";
+import { revalidateTag } from "next/cache";
 import type { HttpError } from "@choosetale/nestia-type";
 import type { UpdateGameReqDto } from "@choosetale/nestia-type/lib/structures/UpdateGameReqDto";
 import { API_URL } from "@/config/config";
@@ -22,6 +23,7 @@ export const updateGame = async (
     });
     const game = (await response.json()) as UpdateGameReqDto;
 
+    revalidateTag("game-info");
     return { success: true, game };
   } catch (error) {
     return { success: false, error: error as HttpError };

--- a/apps/game-builder/src/actions/page/createPage.ts
+++ b/apps/game-builder/src/actions/page/createPage.ts
@@ -1,4 +1,5 @@
 "use server";
+import { revalidateTag } from "next/cache";
 import type { HttpError } from "@choosetale/nestia-type";
 import type { CreatePageResDto } from "@choosetale/nestia-type/lib/structures/CreatePageResDto";
 import { API_URL } from "@/config/config";
@@ -22,6 +23,7 @@ export const createPage = async (
     });
     const page = (await response.json()) as CreatePageResDto;
 
+    revalidateTag("game-all");
     return { success: true, page };
   } catch (error) {
     return { success: false, error: error as HttpError };

--- a/apps/game-builder/src/actions/page/deletePage.ts
+++ b/apps/game-builder/src/actions/page/deletePage.ts
@@ -1,4 +1,5 @@
 "use server";
+import { revalidateTag } from "next/cache";
 import type { HttpError } from "@choosetale/nestia-type";
 import { API_URL } from "@/config/config";
 
@@ -11,6 +12,7 @@ export const deletePage = async (gameId: number, pageId: number) => {
       },
     });
 
+    revalidateTag("game-all");
     return { success: true };
   } catch (error) {
     return { success: false, error: error as HttpError };

--- a/apps/game-builder/src/actions/page/updatePage.ts
+++ b/apps/game-builder/src/actions/page/updatePage.ts
@@ -1,4 +1,5 @@
 "use server";
+import { revalidateTag } from "next/cache";
 import type { HttpError } from "@choosetale/nestia-type";
 import type { UpdatePageResDto } from "@choosetale/nestia-type/lib/structures/UpdatePageResDto";
 import { API_URL } from "@/config/config";
@@ -27,6 +28,7 @@ export const updatePage = async (
     });
     const page = (await response.json()) as UpdatePageResDto;
 
+    revalidateTag("game-all");
     return { success: true, page };
   } catch (error) {
     return { success: false, error: error as HttpError };

--- a/apps/game-builder/src/actions/thumbnail/deleteThumbnail.ts
+++ b/apps/game-builder/src/actions/thumbnail/deleteThumbnail.ts
@@ -1,4 +1,5 @@
 "use server";
+import { revalidateTag } from "next/cache";
 import type { HttpError } from "@choosetale/nestia-type";
 import { API_URL } from "@/config/config";
 import type { ApiResponse, SuccessResponse } from "../action";
@@ -20,6 +21,7 @@ export const deleteThumbnail = async (
       throw new Error(errorData.message || "Failed to delete thumbnail");
     }
 
+    revalidateTag("game-info");
     return { success: true };
   } catch (error) {
     return { success: false, error: error as HttpError };

--- a/apps/game-builder/src/actions/thumbnail/generateThumbnail.ts
+++ b/apps/game-builder/src/actions/thumbnail/generateThumbnail.ts
@@ -1,4 +1,5 @@
 "use server";
+import { revalidateTag } from "next/cache";
 import type { HttpError } from "@choosetale/nestia-type";
 import { API_URL } from "@/config/config";
 import type { ApiResponse, SuccessResponse } from "../action";
@@ -24,6 +25,7 @@ export const generateThumbnail = async (
 
     const generatedThumbnail = await response.json();
 
+    revalidateTag("game-info");
     return {
       success: true,
       generatedThumbnail,

--- a/apps/game-builder/src/actions/thumbnail/uploadThumbnail.ts
+++ b/apps/game-builder/src/actions/thumbnail/uploadThumbnail.ts
@@ -1,4 +1,5 @@
 "use server";
+import { revalidateTag } from "next/cache";
 import type { HttpError } from "@choosetale/nestia-type";
 import { API_URL } from "@/config/config";
 import type { ApiResponse, SuccessResponse } from "../action";
@@ -34,6 +35,7 @@ export const uploadThumbnail = async (
       throw new Error("Failed to upload thumbnails");
     }
 
+    revalidateTag("game-info");
     return { success: true, uploadedThumbnail: data[0] };
   } catch (error) {
     return { success: false, error: error as HttpError };

--- a/apps/game-builder/tailwind.config.ts
+++ b/apps/game-builder/tailwind.config.ts
@@ -4,7 +4,7 @@ import sharedConfig from "@repo/tailwind-config";
 const config: Pick<Config, "content" | "presets" | "plugins"> = {
   content: ["./src/**/*.tsx"],
   presets: [sharedConfig],
-  plugins: [require("@tailwindcss/line-clamp"), require("tailwindcss-animate")],
+  plugins: [require("tailwindcss-animate")],
 };
 
 export default config;


### PR DESCRIPTION

## fix: 썸네일 삭제 이후 캐시 revalidate
- confirm에서 썸네일 삭제 이후 뒤로 가기로 이동 후 다시 confirm 페이지로 돌아왔을 때, 썸네일 삭제 이전 데이터가 보이는 상태 이상 수정
- next Fetch API의 tags 사용
```tsx
await fetch(`${API_URL}/game/${gameId}`, {
  ...
  next: { tags: ["game", "game-info"] }, // tag => tanstack의 쿼리키와 유사
});

```
- 삭제 액션에 해당 태그로 메소드 실행
```tsx
revalidateTag("game-info"); // 서버측에서 사용해야 합니다
```

## refactor: 경우에 맞도록 각 액션에 revalidate 적용
- 추가한 태그: game, game-all, game-info
- 페이지 전체에 `dynamic = 'force-dynamic'`을 사용하거나, 해당 요청에 `cache: no-store`를 작성하여 캐시를 전혀 적용하지 않는 것보다, 액션을 실행했을 때만 "game-info", "game-all"의 캐시를 무효화하는 것이 효율적이라고 생각하여 revalidateTag를 추가했습니다.