### PR TITLE
fix(S1): 선택지 수정 아이콘 통일

### DIFF
--- a/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
+++ b/apps/game-builder/src/components/card/choice/ChoiceCard.tsx
@@ -2,10 +2,9 @@
 import { useState } from "react";
 import { useForm } from "react-hook-form";
 import {
-  CheckIcon,
   Cross2Icon,
   Link2Icon,
-  LockOpen2Icon,
+  Pencil2Icon,
   PlusCircledIcon,
   TrashIcon,
 } from "@radix-ui/react-icons";
@@ -138,22 +137,12 @@ export default function ChoiceCard({
         </div>
 
         <CardFooter className="flex flex-col justify-end items-center p-0 pr-4 py-4 gap-2">
-          {isSavedChoice && (
-            <ThemedIconButton
-              type="submit"
-              className="!absolute top-1 right-1 min-w-6 p-0 min-h-0 px-2 py-[2px]"
-            >
-              <LockOpen2Icon className="h-4 w-4" />
-            </ThemedIconButton>
-          )}
-          {!isSavedChoice && (
-            <ThemedIconButton
-              type="submit"
-              className="!absolute top-1 right-1 min-w-6 p-0 min-h-0 px-2 py-[2px]"
-            >
-              <CheckIcon className="h-6 w-6" />
-            </ThemedIconButton>
-          )}
+          <ThemedIconButton
+            type="submit"
+            className="!absolute top-1 right-1 min-w-6 p-0 min-h-0 px-2 py-[2px]"
+          >
+            <Pencil2Icon className="h-4 w-4" />
+          </ThemedIconButton>
           {isSavedChoice && (
             <ThemedIconButton onClick={handleCancel}>
               <Cross2Icon className="h-6 w-6" />

--- a/apps/game-builder/src/components/card/choice/StaticChoice.tsx
+++ b/apps/game-builder/src/components/card/choice/StaticChoice.tsx
@@ -1,4 +1,4 @@
-import { LockClosedIcon, TrashIcon } from "@radix-ui/react-icons";
+import { Pencil2Icon, TrashIcon } from "@radix-ui/react-icons";
 import {
   CardContent,
   CardDescription,
@@ -61,7 +61,7 @@ export function StaticChoice({
             onClick={editChoice}
             className="!absolute top-1 right-1 min-w-6 p-0 min-h-0 px-2 py-[2px]"
           >
-            <LockClosedIcon className="h-4 w-4" />
+            <Pencil2Icon className="h-4 w-4" />
           </ThemedIconButton>
           <ThemedIconButton onClick={removeChoice}>
             <TrashIcon className="h-7 w-7 m-[2px]" />


### PR DESCRIPTION
# 세 가지 경우의 선택지 수정 아이콘 통일
- 선택지의 우측 상단 아이콘을 연필 아이콘으로 고정
  - 아이콘을 생성/수정/고정 역할에 따라 다르게 사용했더니, 오히려 사용성이 낮아지는 현상이 발생하기 때문에 통일합니다. 
![image](https://github.com/user-attachments/assets/11cc0ced-52a9-46de-9a5a-9684a3e25eeb)
![image](https://github.com/user-attachments/assets/96078590-1041-4e48-9e59-188ea4b587cd)
