### PR TITLE
feat(S1): 텍스트 에디터 CLS 개선

### DIFF
--- a/apps/game-builder/src/components/common/editor/DescriptionEditor.tsx
+++ b/apps/game-builder/src/components/common/editor/DescriptionEditor.tsx
@@ -18,9 +18,11 @@ export default function PageContentEditor({
   initialValue,
   onChange,
   errMsg,
+  height: heightProp,
   ...props
 }: PageContentProps) {
   const ref = useRef<Editor>(null);
+  const height = heightProp ? heightProp : "40vh";
 
   useEffect(() => {
     if (!ref.current) return;
@@ -44,13 +46,16 @@ export default function PageContentEditor({
 
   return (
     <div id="editor">
-      <div className={`${errMsg && "rounded-sm border border-red-500"}`}>
+      <div
+        className={`bg-gray-100 ${errMsg && "border rounded-sm border-red-500"}`}
+        style={{ minHeight: height }}
+      >
         <DynamicEditor
           forwardedRef={ref}
           initialValue={initialValue}
           onChange={handleChange}
           placeholder="페이지의 내용을 입력하세요"
-          height="40vh"
+          height={height}
           initialEditType="wysiwyg"
           hideModeSwitch
           toolbarItems={[

--- a/apps/game-builder/src/components/game/confirm/form/GameConfirmFields.tsx
+++ b/apps/game-builder/src/components/game/confirm/form/GameConfirmFields.tsx
@@ -85,7 +85,7 @@ export default function GameConfirmFields({
       <GenresSelect name="genre" labelText="게임 장르" control={control} />
 
       <MaxLengthText {...descriptionMaxLengthOptions} className="top-0" />
-      <div>
+      <div className="h-[20vh] bg-gray-100">
         <PageContentEditor
           initialValue={watch("description") || "<p></p>"}
           onChange={handleEditorChange}


### PR DESCRIPTION
- PageContentEditor.tsx에서 props로 받아온 height로, 회색 배경의 min-height 스타일 추가
- ToastUI 높이만큼 로딩 시에 레이아웃 쉬프트 현상 발생하는 점 수정