### PR TITLE
feat(S0): 모바일 레이아웃 UI 수정

### DIFF
--- a/apps/game-builder/src/app/layout.tsx
+++ b/apps/game-builder/src/app/layout.tsx
@@ -10,7 +10,8 @@ const inter = Inter({ subsets: ["latin"] });
 
 export const metadata: Metadata = {
   title: "ChooseTale",
-  description: "게임 만들기",
+  description:
+    "ChooseTale은 텍스트 기반의 게임을 만들고 공유할 수 있어요. AI와 함께 새로운 이야기를 만들어보세요!",
 };
 
 export default function RootLayout({
@@ -24,7 +25,7 @@ export default function RootLayout({
         <Toaster />
         <MobileWrapper>
           <CSSThemeProvider>
-            <div className="h-[calc(100vh-80px)] flex flex-col">
+            <div className="h-full flex flex-col">
               <div className="flex-1 overflow-y-scroll">
                 <div className="w-full h-full flex flex-col">{children}</div>
               </div>

--- a/apps/game-builder/src/packages/ui/components/MobileWrapper.tsx
+++ b/apps/game-builder/src/packages/ui/components/MobileWrapper.tsx
@@ -4,8 +4,14 @@ import NavBar from "./NavBar";
 
 export default function MobileWrapper({ children }: PropsWithChildren) {
   return (
-    <div className="w-full h-[calc(100vh-1px)] bg-slate-200">
-      <div className="max-w-xl h-full flex flex-col justify-between mx-auto">
+    <div className="w-full h-[calc(100vh-1px)] flex bg-slate-200">
+      <div className="non-mobile-layout hidden w-full h-full flex justify-center items-center bg-grey">
+        <p className="text-xl text-center leading-relaxed">
+          가로 화면은 지원하지 않습니다🥹 <br />
+          세로 화면으로 전환해 주세요.
+        </p>
+      </div>
+      <div className="mobile-layout max-w-5xl flex flex-col justify-between mx-auto">
         <div className="flex-1">{children}</div>
         <NavBar />
       </div>

--- a/apps/game-builder/src/packages/ui/components/NavBar.tsx
+++ b/apps/game-builder/src/packages/ui/components/NavBar.tsx
@@ -6,11 +6,16 @@ import { NavigationMenu, NavigationMenuItem } from "./ui/NavigationMenu";
 export default function NavBar() {
   return (
     <div className="w-full h-16 md:h-20 lg:h-24 shrink-0 bg-black">
-      <NavigationMenu className="w-full h-full max-w-none px-4 md:px-10 lg:px-12">
+      <NavigationMenu className="w-full h-full max-w-none px-8 md:px-10 lg:px-12">
         <ul className="w-full h-full flex justify-between items-center !mb-0">
           <NavigationMenuItem>
             <Link href="/">
-              <HomeIcon height={24} width={24} color="white" className="m-2" />
+              <HomeIcon
+                height={24}
+                width={24}
+                color="white"
+                className="m-2 w-6 h-6 lg:w-8 lg:h-8"
+              />
             </Link>
           </NavigationMenuItem>
           <NavigationMenuItem>
@@ -19,7 +24,7 @@ export default function NavBar() {
                 height={24}
                 width={24}
                 color="white"
-                className="m-2"
+                className="m-2 w-6 h-6 lg:w-8 lg:h-8"
               />
             </Link>
           </NavigationMenuItem>

--- a/apps/game-builder/src/packages/ui/components/NavBar.tsx
+++ b/apps/game-builder/src/packages/ui/components/NavBar.tsx
@@ -5,8 +5,8 @@ import { NavigationMenu, NavigationMenuItem } from "./ui/NavigationMenu";
 
 export default function NavBar() {
   return (
-    <div className="w-full h-20 shrink-0 bg-black">
-      <NavigationMenu className="w-full h-full max-w-none px-10">
+    <div className="w-full h-16 md:h-20 lg:h-24 shrink-0 bg-black">
+      <NavigationMenu className="w-full h-full max-w-none px-4 md:px-10 lg:px-12">
         <ul className="w-full h-full flex justify-between items-center !mb-0">
           <NavigationMenuItem>
             <Link href="/">

--- a/apps/game-builder/src/packages/ui/styles.css
+++ b/apps/game-builder/src/packages/ui/styles.css
@@ -85,15 +85,15 @@ body {
   }
 }
 
-/* 터치스크린이 있을 때 */
-@media (pointer: coarse) {
+/* 터치스크린이 있거나, 터치스크린이 없고 767px 이하일 때  */
+@media (pointer: coarse), (max-width: 767px) {
   .mobile-layout {
     width: 100vw;
     height: 100%;
   }
 }
 
-/* 터치스크린이 없고, 768px 이상일 때 */
+/* 터치스크린이 없고 768px 이상일 때 */
 @media (pointer: fine) and (min-width: 768px) {
   .mobile-layout {
     width: 30rem;
@@ -106,7 +106,7 @@ body {
 }
 
 /* 가로 화면 전환 방지 */
-@media (orientation: landscape) {
+@media (pointer: coarse) and (orientation: landscape) {
   .mobile-layout {
     display: none;
   }

--- a/apps/game-builder/src/packages/ui/styles.css
+++ b/apps/game-builder/src/packages/ui/styles.css
@@ -84,3 +84,33 @@ body {
     @apply bg-background text-foreground;
   }
 }
+
+/* 터치스크린이 있을 때 */
+@media (pointer: coarse) {
+  .mobile-layout {
+    width: 100vw;
+    height: 100%;
+  }
+}
+
+/* 터치스크린이 없고, 768px 이상일 때 */
+@media (pointer: fine) and (min-width: 768px) {
+  .mobile-layout {
+    width: 30rem;
+    height: 90%;
+    margin: auto;
+    box-sizing: border-box;
+    overflow: hidden;
+    @apply shadow-lg rounded-lg;
+  }
+}
+
+/* 가로 화면 전환 방지 */
+@media (orientation: landscape) {
+  .mobile-layout {
+    display: none;
+  }
+  .non-mobile-layout {
+    display: flex;
+  }
+}


### PR DESCRIPTION
## 모바일(터치 가능) 기준으로 레이아웃 가로 제한 추가

```css
@media (pointer: coarse) {
  /* 터치스크린이 있을 때 */
  .mobile-layout {
    width: 100vw;
    height: 100%;
  }
}

@media (pointer: fine) and (min-width: 768px) {
  /* 터치스크린이 없을 때 */
  .mobile-layout {
    width: 30rem;
    height: 90%;
    margin: auto;
    box-sizing: border-box;
    overflow: hidden;
    @apply shadow-lg rounded-lg;
  }
}

```

## Navbar 사이즈 수정

### 높이
- 모바일: 64px
- 태블릿: 80px
- 데스크탑: 96px

### 아이콘 사이즈
- 모바일: 24px
- 태블릿/데스크탑: 32px


## 스크린샷
- iPad Pro
![image](https://github.com/user-attachments/assets/0ab5f023-b8b1-49ab-bdb3-21dbadd31441)
- iPhone 12 Pro
![image](https://github.com/user-attachments/assets/4f9ec59f-1fa2-4621-ac1b-9c53ac300097)
- 가로 화면
![image](https://github.com/user-attachments/assets/74161d46-7eb4-473b-8aec-fd68da6e642b)
- 데스크탑이고, 가로 사이즈가 768px 이상일 때
![image](https://github.com/user-attachments/assets/dac75be7-3c1c-484c-af78-39ea29f67c58)
