### PR TITLE
feat(S0): 더미게임 시작 버튼 링크 및 텍스트 변경

### DIFF
--- a/apps/game-builder/src/components/game/landing/LandingButtonBox.tsx
+++ b/apps/game-builder/src/components/game/landing/LandingButtonBox.tsx
@@ -23,13 +23,13 @@ export default function LandingButtonBox() {
           <p className="text-lg">게임 만들기</p>
         </ThemedButton>
       </Link>
-      <Link href="/game-play/start?gameId=1">
+      <Link href="/game/1/intro">
         <ThemedButton
           variant="ghost"
           className="w-full h-auto border border-b-2 border-black gap-2"
         >
           <AllSidesIcon />
-          <p className="text-lg">게임 시작</p>
+          <p className="text-lg">게임1 시작</p>
         </ThemedButton>
       </Link>
     </>

--- a/apps/game-builder/src/packages/ui/components/NavBar.tsx
+++ b/apps/game-builder/src/packages/ui/components/NavBar.tsx
@@ -32,7 +32,7 @@ export default function NavBar() {
             </Link>
           </NavigationMenuItem>
           <NavigationMenuItem>
-            <Link href="/game/create">
+            <Link href="/game/1/intro">
               <AllSidesIcon
                 height={24}
                 width={24}


### PR DESCRIPTION
- 기존 `gameId 1`의 game-play로 바로 이동하던 링크 버튼을 -> `gameId 1`의 인트로 페이지로 이동하도록 변경했습니다.
![image](https://github.com/user-attachments/assets/0cf50ed0-da1f-4d6b-80e6-4e7720ce8887)
