### PR TITLE
feat(S0): 텍스트 커서 애니메이션 컴포넌트 추가, 랜딩 링크 버튼에 적용

### DIFF
--- a/apps/game-builder/src/components/common/text/TypingText.tsx
+++ b/apps/game-builder/src/components/common/text/TypingText.tsx
@@ -1,0 +1,49 @@
+"use client";
+import { motion } from "framer-motion";
+
+interface TypingTextProps {
+  text: string;
+  initialDelay?: number;
+}
+
+export default function TypingText({
+  text,
+  initialDelay = 1,
+}: TypingTextProps) {
+  return (
+    <div className="relative">
+      <motion.div
+        initial={{ opacity: 1 }}
+        animate={{ opacity: 0 }}
+        transition={{ delay: initialDelay, duration: 0.1 }}
+      >
+        <motion.div
+          className="typing-cursor absolute bottom-0 left-0 w-3 h-[2px] mt-auto mb-1 bg-black"
+          animate={{ opacity: [1, 0, 1] }}
+          transition={{
+            duration: 0.25,
+            repeatDelay: 0.25,
+            repeat: Infinity,
+            repeatType: "loop",
+          }}
+        />
+      </motion.div>
+
+      <p className="text-lg">
+        {text.split("").map((char, index) => (
+          <motion.span
+            key={index}
+            initial={{ opacity: 0, y: 10 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{
+              delay: initialDelay + index * 0.05,
+              duration: 0.001,
+            }}
+          >
+            {char}
+          </motion.span>
+        ))}
+      </p>
+    </div>
+  );
+}

--- a/apps/game-builder/src/components/game/landing/LandingButtonBox.tsx
+++ b/apps/game-builder/src/components/game/landing/LandingButtonBox.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import { AllSidesIcon } from "@radix-ui/react-icons";
 import ThemedButton from "@/components/theme/ui/ThemedButton";
 import penIcon from "@asset/icon/pen.png";
+import TypingText from "@/components/common/text/TypingText";
 
 export default function LandingButtonBox() {
   return (
@@ -17,10 +18,10 @@ export default function LandingButtonBox() {
             src={penIcon}
             width={16}
             height={16}
-            className="w-4 h-4 grow-0 shirnk-0"
+            className="w-4 h-4 grow-0 shrink-0"
             alt="choice"
           />
-          <p className="text-lg">게임 만들기</p>
+          <TypingText text="게임 만들기" initialDelay={0.2} />
         </ThemedButton>
       </Link>
       <Link href="/game/1/intro">
@@ -29,7 +30,7 @@ export default function LandingButtonBox() {
           className="w-full h-auto border border-b-2 border-black gap-2"
         >
           <AllSidesIcon />
-          <p className="text-lg">게임1 시작</p>
+          <TypingText text="게임1 시작" initialDelay={0.75} />
         </ThemedButton>
       </Link>
     </>

--- a/apps/game-builder/src/packages/ui/styles.css
+++ b/apps/game-builder/src/packages/ui/styles.css
@@ -114,3 +114,20 @@ body {
     display: flex;
   }
 }
+/* 
+@keyframes blink {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.typing-cursor {
+  display: inline-block;
+  animation: blink 0.7s step-start infinite;
+} */


### PR DESCRIPTION
## 텍스트 커서 애니메이션 컴포넌트 추가
- `TypingText.tsx`
- 글자를 한 글자씩 출력합니다.
- initialDelay를 props로 넘겨서 최초 애니메이션 단계(텍스트를 입력하기 전 커서의 깜박임)의 시간을 조절할 수 있도록 구현

https://github.com/user-attachments/assets/c1f7cec1-b699-4a8f-90ac-ffbe2df191d1

