### PR TITLE
feat(S2): 엔딩 페이지 경우 추가, 게임 플레이 버튼 varient 변경

### DIFF
--- a/apps/game-builder/src/components/button/GameContinueButton.tsx
+++ b/apps/game-builder/src/components/button/GameContinueButton.tsx
@@ -12,9 +12,12 @@ export default function GameContinueButton({
 }) {
   return (
     <Link href={`/game-play/${playId}?gameId=${gameId}`} className="w-full">
-      <Button className="w-full">
-        이어하기{" "}
-        <span className="overflow-hidden whitespace-nowrap overflow-ellipsis">
+      <Button
+        className="w-full h-auto border border-b-2 border-black text-lg"
+        variant="ghost"
+      >
+        이어하기
+        <span className="overflow-hidden whitespace-nowrap overflow-ellipsis !text-xs">
           {lastPageAbridgement ? `: ${lastPageAbridgement}` : ""}
         </span>
       </Button>

--- a/apps/game-builder/src/components/button/GameRestartButton.tsx
+++ b/apps/game-builder/src/components/button/GameRestartButton.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useRouter } from "next/navigation";
+import { ReloadIcon } from "@radix-ui/react-icons";
 import { Button } from "@/packages/ui/components/ui/Button";
 
 export default function GameRestartButton({ gameId }: { gameId: number }) {
@@ -12,7 +13,12 @@ export default function GameRestartButton({ gameId }: { gameId: number }) {
   };
 
   return (
-    <Button className="w-full" variant="outline" onClick={handleRestartClick}>
+    <Button
+      className="w-full h-auto border border-b-2 border-black gap-2 text-lg"
+      variant="ghost"
+      onClick={handleRestartClick}
+    >
+      <ReloadIcon />
       새로 하기
     </Button>
   );

--- a/apps/game-builder/src/components/button/GameStartButton.tsx
+++ b/apps/game-builder/src/components/button/GameStartButton.tsx
@@ -9,7 +9,11 @@ export default function GameStartButton({ gameId }: { gameId: number }) {
   };
 
   return (
-    <Button className="w-full" variant="outline" onClick={handleRestartClick}>
+    <Button
+      className="w-full h-auto border border-b-2 border-black text-lg"
+      variant="ghost"
+      onClick={handleRestartClick}
+    >
       게임 시작
     </Button>
   );

--- a/apps/game-builder/src/components/button/game-play/GameResultButton.tsx
+++ b/apps/game-builder/src/components/button/game-play/GameResultButton.tsx
@@ -1,0 +1,15 @@
+import Link from "next/link";
+import { Button } from "@/packages/ui/components/ui/Button";
+
+export default function GameResultButton({ playId }: { playId: number }) {
+  return (
+    <Link href={`/game-play/${playId}/result`} className="w-full">
+      <Button
+        className="w-full h-auto border border-b-2 border-black gap-2 text-lg"
+        variant="ghost"
+      >
+        결과 확인
+      </Button>
+    </Link>
+  );
+}

--- a/apps/game-builder/src/components/game-play/play/EndingPageButtonBox.tsx
+++ b/apps/game-builder/src/components/game-play/play/EndingPageButtonBox.tsx
@@ -1,0 +1,25 @@
+import { motion } from "framer-motion";
+import GameRestartButton from "@/components/button/GameRestartButton";
+import GameResultButton from "@/components/button/game-play/GameResultButton";
+
+interface EndingPageButtonBoxProps {
+  playId: number;
+  gameId: number;
+}
+
+export default function EndingPageButtonBox({
+  playId,
+  gameId,
+}: EndingPageButtonBoxProps) {
+  return (
+    <motion.div
+      className="flex flex-col gap-3"
+      initial={{ opacity: 0, y: 50 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+    >
+      <GameResultButton playId={playId} />
+      <GameRestartButton gameId={gameId} />
+    </motion.div>
+  );
+}

--- a/apps/game-builder/src/components/game-play/play/GamePlay.tsx
+++ b/apps/game-builder/src/components/game-play/play/GamePlay.tsx
@@ -3,8 +3,8 @@ import { useEffect, useState } from "react";
 import { notFound, useSearchParams } from "next/navigation";
 import { type GamePlayParams } from "@/app/(game-play)/game-play/[playId]/page";
 import { type GameIntro as GameIntroType } from "@/interface/customType";
-import PlayPage from "./PlayPage";
 import { getGameIntro } from "@/actions/game-play/getIntro";
+import PlayPage from "./PlayPage";
 
 export default function GameIntro({ playId }: GamePlayParams) {
   const [gameIntroResponse, setGameIntroResponse] =

--- a/apps/game-builder/src/components/game-play/play/PlayChoices.tsx
+++ b/apps/game-builder/src/components/game-play/play/PlayChoices.tsx
@@ -30,7 +30,7 @@ export default function PlayChoices({
       >
         {choices.map((choice, index) => (
           <motion.li
-            className="flex gap-1 hover:font-bold"
+            className="flex gap-1 hover:underline"
             key={choice.id}
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}

--- a/apps/game-builder/src/components/game-play/play/PlayPage.tsx
+++ b/apps/game-builder/src/components/game-play/play/PlayPage.tsx
@@ -5,6 +5,7 @@ import { getGamePlayPage } from "@/actions/game-play/getGamePlayPage";
 import { postGamePlayChoice } from "@/actions/game-play/postGamePlayChoice";
 import TypingHtml from "@/components/common/text/TypingHtml";
 import PlayChoices from "./PlayChoices";
+import EndingPageButtonBox from "./EndingPageButtonBox";
 
 export default function PlayPage({
   gameId,
@@ -21,12 +22,13 @@ export default function PlayPage({
   );
   const [loading, setLoading] = useState(true);
   const [choiceSending, setChoiceSending] = useState(false);
+  const isEnding = gamePlayResponse?.page?.isEnding;
 
   useEffect(() => {
     async function startGame() {
       setLoading(true);
       try {
-        const response = await getGamePlayPage(playId, currentPageId);
+        const response = await getGamePlayPage(gameId, currentPageId);
 
         response.success && setGamePlayResponse(response.gamePlayPage);
       } catch (error) {
@@ -37,14 +39,15 @@ export default function PlayPage({
     }
 
     startGame();
-  }, [playId, currentPageId]);
+  }, [playId, currentPageId, gameId]);
 
   if (loading) {
     return null;
   }
 
   if (!gamePlayResponse) notFound();
-  const page = gamePlayResponse?.page[0];
+  const page = gamePlayResponse?.page;
+  if (!page) notFound();
 
   const handleChoiceClick = async (choiceId: number) => {
     if (choiceSending) return;
@@ -66,15 +69,24 @@ export default function PlayPage({
   return (
     <>
       <div className="pt-6 pb-8 min-h-24">
+        {isEnding ? (
+          <h1 className="text-2xl font-bold text-center mb-8">이야기의 끝</h1>
+        ) : (
+          ""
+        )}
         <TypingHtml htmlContent={page.description} speed="fast" />
       </div>
 
-      <PlayChoices
-        choiceSending={choiceSending}
-        choices={page.choices}
-        handleChoiceClick={handleChoiceClick}
-        pageLength={page.description.length}
-      />
+      {!isEnding && (
+        <PlayChoices
+          choiceSending={choiceSending}
+          choices={page.choices}
+          handleChoiceClick={handleChoiceClick}
+          pageLength={page.description.length}
+        />
+      )}
+
+      {isEnding ? <EndingPageButtonBox gameId={gameId} playId={playId} /> : ""}
     </>
   );
 }

--- a/apps/game-builder/src/components/game/intro/GameIntro.tsx
+++ b/apps/game-builder/src/components/game/intro/GameIntro.tsx
@@ -4,12 +4,13 @@ import { ClockIcon, InfoCircledIcon, Pencil1Icon } from "@radix-ui/react-icons";
 import { AspectRatio } from "@repo/ui/components/ui/AspectRatio";
 import type { GameIntro as GameIntroType } from "@/interface/customType";
 import DateDisplay from "@/components/common/text/DateDisplay";
-import { DynamicViewer } from "@/components/common/viewer/DynamicViewer";
 import TextWithCounts from "@/components/common/text/TextWithCounts";
 import TextWithNumberRange from "@/components/common/text/TextWithCountsRange";
 import GameRestartButton from "@/components/button/GameRestartButton";
 import GameContinueButton from "@/components/button/GameContinueButton";
 import GameStartButton from "@/components/button/GameStartButton";
+import TypingHtml from "@/components/common/text/TypingHtml";
+import TypingTextWithCursor from "@/components/common/text/TypingTextWithCursor";
 
 export default function GameIntro({
   gameIntroData,
@@ -39,14 +40,11 @@ export default function GameIntro({
             )}
           </AspectRatio>
         </div>
-        <h1 className="text-2xl font-bold">{gameData.title}</h1>
+        <h1 className="text-2xl font-bold">
+          <TypingTextWithCursor text={gameData.title} />
+        </h1>
         <div className="my-10">
-          <DynamicViewer
-            initialEditType="markdown"
-            previewStyle="vertical"
-            height="600px"
-            initialValue={gameData.description}
-          />
+          <TypingHtml htmlContent={gameData.description} initialDelay={1.5} />
         </div>
 
         <div className="xs:mx-6 sm:mx-12 flex flex-col gap-1 flex-1 items-end min-w-[230px]">


### PR DESCRIPTION
## 작업

- 게임 플레이 뷰에서 엔딩 페이지의 경우 추가
![image](https://github.com/user-attachments/assets/e43ebea7-7187-412c-a991-92cdeaf2a9af)

- 게임 플레이 버튼 UI: 버튼 4종의 varient를 ghost로 통일
  - 게임 시작
  - 게임 이어하기
  - 게임 재시작
  - 결과 보기
![image](https://github.com/user-attachments/assets/5c15dfb4-80ed-492a-9a93-58b91e451d2d)
![image](https://github.com/user-attachments/assets/4b7e34a0-0da2-4a7b-85ef-350f17e0cf4f)
