### PR TITLE
feat(S2): 게임 플레이 애니메이션 스킵 기능

### DIFF
--- a/apps/game-builder/src/app/(game-play)/layout.tsx
+++ b/apps/game-builder/src/app/(game-play)/layout.tsx
@@ -1,5 +1,9 @@
 import type { ReactNode } from "react";
 
 export default function Layout({ children }: { children: ReactNode }) {
-  return <div className="w-full h-full px-12 py-8">{children}</div>;
+  return (
+    <div className="w-full h-full px-12 pt-8 pb-12 overflow-y-auto">
+      {children}
+    </div>
+  );
 }

--- a/apps/game-builder/src/components/common/BackgroundWapper.tsx
+++ b/apps/game-builder/src/components/common/BackgroundWapper.tsx
@@ -13,12 +13,14 @@ export default function BackgroundWapper({
         src={texture.src}
         sizes="100vw"
         alt="Background Texture"
-        layout="fill"
+        fill
         style={{ objectFit: "cover" }}
         priority
         quality={75}
       />
-      <div className="relative w-full h-full z-10">{children}</div>
+      <div className="relative w-full h-full z-10 overflow-y-auto">
+        {children}
+      </div>
     </div>
   );
 }

--- a/apps/game-builder/src/components/common/text/TypingText.tsx
+++ b/apps/game-builder/src/components/common/text/TypingText.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useState } from "react";
 import { motion } from "framer-motion";
 
 export interface TypingTextProps {
@@ -15,6 +16,8 @@ export default function TypingText({
   speed = "normal",
   className = "",
 }: TypingTextProps) {
+  const [skip, setSkip] = useState(false);
+
   const typingSpeed = {
     slow: 0.1,
     normal: 0.05,
@@ -25,21 +28,25 @@ export default function TypingText({
 
   return (
     <>
-      {text.split("").map((char, index) => (
-        <motion.span
-          // eslint-disable-next-line react/no-array-index-key -- Using index as key because content has no unique identifier
-          key={char + index}
-          initial={{ opacity: 0, y: 10 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{
-            delay: currentDelay + index * currentSpeed,
-            duration: 0.001,
-          }}
-          className={className}
-        >
-          {char}
-        </motion.span>
-      ))}
+      {skip
+        ? text
+        : text.split("").map((char, index) => (
+            <motion.span
+              // eslint-disable-next-line react/no-array-index-key -- Using index as key because content has no unique identifier
+              key={char + index}
+              initial={{ opacity: 0 }}
+              animate={{ opacity: 1 }}
+              transition={{
+                delay: skip ? 0 : currentDelay + index * currentSpeed,
+                duration: 0.001,
+              }}
+              className={className}
+              onClick={() => setSkip(true)}
+              onTouchStart={() => setSkip(true)}
+            >
+              {char}
+            </motion.span>
+          ))}
     </>
   );
 }

--- a/apps/game-builder/src/components/game-play/play/PlayChoices.tsx
+++ b/apps/game-builder/src/components/game-play/play/PlayChoices.tsx
@@ -1,6 +1,8 @@
+import { useState } from "react";
 import Image from "next/image";
 import { motion } from "framer-motion";
 import type { ApiChoice } from "@/interface/customType";
+import { TextAlignTopIcon } from "@radix-ui/react-icons";
 import penIcon from "@asset/icon/pen.png";
 
 interface PlayPageProps {
@@ -16,29 +18,82 @@ export default function PlayChoices({
   handleChoiceClick,
   pageLength,
 }: PlayPageProps) {
+  const [skip, setSkip] = useState(false);
   const initialDelay = 0.015 * pageLength;
 
   return (
-    <motion.div
-      initial={{ opacity: 0, y: 10 }}
-      animate={{ opacity: 1, y: 0 }}
-      transition={{ duration: 0.3, delay: initialDelay + 0.2 }}
-    >
-      <hr className="border-black my-8" />
-      <ol
-        className={`flex flex-col gap-4 ${choiceSending ? "animate-false" : ""}`}
-      >
-        {choices.map((choice, index) => (
-          <motion.li
-            className="flex gap-1 hover:underline"
-            key={choice.id}
+    <>
+      {skip ? (
+        <StaticChoices
+          choices={choices}
+          handleChoiceClick={handleChoiceClick}
+        />
+      ) : (
+        <>
+          <div className="flex justify-end">
+            <TextAlignTopIcon
+              onClick={() => setSkip(true)}
+              onTouchStart={() => setSkip(true)}
+              className="cursor-pointer"
+            />
+          </div>
+          <motion.div
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
-            transition={{
-              duration: 0.3,
-              delay: initialDelay + 1 + 0.25 * index,
-            }}
+            transition={{ duration: 0.3, delay: initialDelay + 0.2 }}
           >
+            <hr className="border-black my-8 pointer-none" />
+            <ol
+              className={`flex flex-col gap-4 ${choiceSending ? "animate-false pointer-events-none" : ""}`}
+            >
+              {choices.map((choice, index) => (
+                <motion.li
+                  className="flex gap-1 hover:underline"
+                  key={choice.id}
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{
+                    duration: 0.3,
+                    delay: initialDelay + 1 + 0.25 * index,
+                  }}
+                >
+                  <Image
+                    src={penIcon}
+                    width={16}
+                    height={16}
+                    className="mt-1 w-4 h-4 grow-0 shirnk-0"
+                    alt="choice"
+                  />
+                  <button
+                    type="button"
+                    className="text-left"
+                    onClick={() => handleChoiceClick(choice.id)}
+                  >
+                    {choice.description}
+                  </button>
+                </motion.li>
+              ))}
+            </ol>
+          </motion.div>
+        </>
+      )}
+    </>
+  );
+}
+
+function StaticChoices({
+  choices,
+  handleChoiceClick,
+}: {
+  choices: ApiChoice[];
+  handleChoiceClick: (choiceId: number) => void;
+}) {
+  return (
+    <>
+      <hr className="border-black my-8 pointer-none" />
+      <ol className="flex flex-col gap-4">
+        {choices.map((choice) => (
+          <li className="flex gap-1 hover:underline" key={choice.id}>
             <Image
               src={penIcon}
               width={16}
@@ -53,9 +108,9 @@ export default function PlayChoices({
             >
               {choice.description}
             </button>
-          </motion.li>
+          </li>
         ))}
       </ol>
-    </motion.div>
+    </>
   );
 }

--- a/apps/game-builder/src/components/game-play/play/PlayChoices.tsx
+++ b/apps/game-builder/src/components/game-play/play/PlayChoices.tsx
@@ -30,13 +30,22 @@ export default function PlayChoices({
         />
       ) : (
         <>
-          <div className="flex justify-end">
+          <motion.div
+            className="flex justify-end relative h-0"
+            initial={{ opacity: 1, y: 0 }}
+            animate={{ opacity: 0, y: -5 }}
+            transition={{
+              duration: 0.2,
+              delay: initialDelay + 1 + 0.2 * choices.length,
+            }}
+          >
             <TextAlignTopIcon
               onClick={() => setSkip(true)}
               onTouchStart={() => setSkip(true)}
               className="cursor-pointer"
             />
-          </div>
+          </motion.div>
+
           <motion.div
             initial={{ opacity: 0, y: 10 }}
             animate={{ opacity: 1, y: 0 }}
@@ -54,7 +63,7 @@ export default function PlayChoices({
                   animate={{ opacity: 1, y: 0 }}
                   transition={{
                     duration: 0.3,
-                    delay: initialDelay + 1 + 0.25 * index,
+                    delay: initialDelay + 1 + 0.2 * index,
                   }}
                 >
                   <Image


### PR DESCRIPTION
## 상세
아래의 게임 플레이 관련 컴포넌트에, 애니메이션 스킵을 각각 추가했습니다.

1. 텍스트 출력 / 타이핑 애니메이션: 텍스트를 클릭 혹은 터치 시, 애니메이션 스킵
2. 선택지 출력 / fade-in 애니메이션: 선택지 아이콘 버튼을 클릭 시, 애니메이션 스킵

### 선택지 출력 아이콘 추가 관련: `PlayChoices.tsx`
- 페이지 접근 시, 애니메이션이 시작됩니다.
- 애니메이션이 진행 중일 때, 선택지 출력 아이콘이 나타납니다.
- 애니메이션이 종료되면 선택지 출력 아이콘이 사라집니다.
- 선택지 출력 아이콘을 누르면 애니메이션을 스킵하고, 선택지를 바로 출력합니다.
![image](https://github.com/user-attachments/assets/02b97322-d576-4304-9a29-d76686513608)


## 시연
https://github.com/user-attachments/assets/79a5b795-f411-40b3-b78e-6be91642380c

