### PR TITLE
fix(S1): 게임 build 페이지 내 `abridgement` 출력에 태그 제거 유틸 적용

### DIFF
--- a/apps/game-builder/package.json
+++ b/apps/game-builder/package.json
@@ -29,7 +29,7 @@
     "zustand": "^4.5.4"
   },
   "devDependencies": {
-    "@choosetale/nestia-type": "0.1.6",
+    "@choosetale/nestia-type": "0.1.10",
     "@nestia/fetcher": "^3.2.6",
     "@next/eslint-plugin-next": "^14.2.3",
     "@radix-ui/react-aspect-ratio": "^1.1.0",

--- a/apps/game-builder/src/components/card/page/PageCard.tsx
+++ b/apps/game-builder/src/components/card/page/PageCard.tsx
@@ -54,7 +54,7 @@ export default function PageCard({
               className={`mb-2 !text-[16px] break-all ${showChoiceButtons ? "" : "pr-6"}`}
             >
               {abridgement !== "" ? (
-                abridgement
+                removeEditorTags(abridgement)
               ) : (
                 <span className="opacity-20">요약이 없습니다</span>
               )}

--- a/apps/game-builder/src/components/game/create/CreateGame.tsx
+++ b/apps/game-builder/src/components/game/create/CreateGame.tsx
@@ -18,7 +18,6 @@ export default function CreateGame() {
 
   const emptyInitialValue = "<p></p>";
   const onSubmit: SubmitHandler<CreateGameReqDto> = async (data) => {
-    const res = await createGame(data);
     if (data.pageOneContent === emptyInitialValue) {
       useFormProps.setError("pageOneContent", {
         type: "required",
@@ -27,6 +26,8 @@ export default function CreateGame() {
     }
 
     try {
+      const res = await createGame(data);
+
       if (!res.success) throw new Error("게임 생성 실패");
       const gameId = res.gameInitData.id;
       if (!gameId) throw new Error("게임 생성 실패");

--- a/apps/game-builder/src/components/game/edit/GameEditDraw.tsx
+++ b/apps/game-builder/src/components/game/edit/GameEditDraw.tsx
@@ -15,6 +15,7 @@ import ThemedButton from "@/components/theme/ui/ThemedButton";
 import GameEditFields from "@/components/game/edit/form/GameEditFields";
 import type { PageType } from "@/interface/customType";
 import type useGameData from "@/hooks/useGameData";
+import { removeEditorTags } from "@/utils/removeEditorTags";
 import GameEditDrawTriggerButton from "./GameEditDrawTriggerButton";
 import EndingPageSwitch from "./form/EndingPageSwitch";
 
@@ -34,7 +35,12 @@ export default function GameEditDraw({
   updatePage,
 }: GameEditDrawProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const useFormProps = useForm({ defaultValues: page });
+  const useFormProps = useForm({
+    defaultValues: {
+      ...page,
+      abridgement: removeEditorTags(page.abridgement),
+    },
+  });
   const { handleSubmit, reset, control } = useFormProps;
 
   const onSubmit: SubmitHandler<PageType> = (fieldValues) => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         version: 4.5.4(@types/react@18.2.61)(react@18.2.0)
     devDependencies:
       '@choosetale/nestia-type':
-        specifier: 0.1.6
-        version: 0.1.6(typescript@5.3.3)
+        specifier: 0.1.10
+        version: 0.1.10(typescript@5.3.3)
       '@nestia/fetcher':
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.3.3)
@@ -433,8 +433,8 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
-  /@choosetale/nestia-type@0.1.6(typescript@5.3.3):
-    resolution: {integrity: sha512-AtQnwhuKDdAf/wLLIpmzcbjfjJBMbeSPQLv6CnriZkU1akqZ1uVnNddM8wBD2CrxDAx8Dna1P6MgBrriMofIEA==, tarball: https://npm.pkg.github.com/download/@ChooseTale/nestia-type/0.1.6/860e3758718ab47ab315e6da0d8506d3ad7911d1}
+  /@choosetale/nestia-type@0.1.10(typescript@5.3.3):
+    resolution: {integrity: sha512-nCJySdf9EVAVgWSnxSsGPJvQFEL8ItnwI3X0KL1SywS1stkGmo6UjowKWFfzoI79hZ/4zoYuh0gsz9SNM6VxTA==, tarball: https://npm.pkg.github.com/download/@ChooseTale/nestia-type/0.1.10/5a3afb96d9f1afb9ee7e59affca53c34b6818f5b}
     dependencies:
       '@nestia/fetcher': 3.2.6(typescript@5.3.3)
       typia: 6.3.1(typescript@5.3.3)


### PR DESCRIPTION
## 상세
- removeEditorTags 유틸 적용



## 스크린샷

> 예시 참고: 페이지의 제목과 본문을 wysiwyg으로 응답받는 api 오류 발생 중

### 페이지 `abridgement`
- as is
![image](https://github.com/user-attachments/assets/ea571882-6a4c-4db9-9b8c-13a6119c7771)
- to be
![image](https://github.com/user-attachments/assets/3c41d8ae-e371-4cc3-85f5-48e5878a2b2a)

### 페이지 form의 `abridgement`

- as is
![image](https://github.com/user-attachments/assets/22d5e997-e247-4c17-a742-e8b1a7945596)
- to be
![image](https://github.com/user-attachments/assets/88936cde-ccaf-47bf-b664-98f621e3879e)
