### PR TITLE
fix(S1): 요약 비공개 안내 메시지 삭제

### DIFF
--- a/apps/game-builder/package.json
+++ b/apps/game-builder/package.json
@@ -29,7 +29,7 @@
     "zustand": "^4.5.4"
   },
   "devDependencies": {
-    "@choosetale/nestia-type": "0.1.6",
+    "@choosetale/nestia-type": "0.1.10",
     "@nestia/fetcher": "^3.2.6",
     "@next/eslint-plugin-next": "^14.2.3",
     "@radix-ui/react-aspect-ratio": "^1.1.0",

--- a/apps/game-builder/src/components/game/edit/form/GameEditFields.tsx
+++ b/apps/game-builder/src/components/game/edit/form/GameEditFields.tsx
@@ -65,9 +65,6 @@ export default function GameEditFields({
         autoComplete="off"
         errMsg={errors.abridgement?.message ?? ""}
       />
-      <p className="text-xs text-right text-gray-400 h-0 -translate-y-2">
-        요약은 플레이어에게 보이지 않습니다.
-      </p>
 
       <MaxLengthText {...descriptionMaxLengthOptions} className="-top-1" />
       <PageContentEditor

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,8 +79,8 @@ importers:
         version: 4.5.4(@types/react@18.2.61)(react@18.2.0)
     devDependencies:
       '@choosetale/nestia-type':
-        specifier: 0.1.6
-        version: 0.1.6(typescript@5.3.3)
+        specifier: 0.1.10
+        version: 0.1.10(typescript@5.3.3)
       '@nestia/fetcher':
         specifier: ^3.2.6
         version: 3.2.6(typescript@5.3.3)
@@ -433,8 +433,8 @@ packages:
       to-fast-properties: 2.0.0
     dev: true
 
-  /@choosetale/nestia-type@0.1.6(typescript@5.3.3):
-    resolution: {integrity: sha512-AtQnwhuKDdAf/wLLIpmzcbjfjJBMbeSPQLv6CnriZkU1akqZ1uVnNddM8wBD2CrxDAx8Dna1P6MgBrriMofIEA==, tarball: https://npm.pkg.github.com/download/@ChooseTale/nestia-type/0.1.6/860e3758718ab47ab315e6da0d8506d3ad7911d1}
+  /@choosetale/nestia-type@0.1.10(typescript@5.3.3):
+    resolution: {integrity: sha512-nCJySdf9EVAVgWSnxSsGPJvQFEL8ItnwI3X0KL1SywS1stkGmo6UjowKWFfzoI79hZ/4zoYuh0gsz9SNM6VxTA==, tarball: https://npm.pkg.github.com/download/@ChooseTale/nestia-type/0.1.10/5a3afb96d9f1afb9ee7e59affca53c34b6818f5b}
     dependencies:
       '@nestia/fetcher': 3.2.6(typescript@5.3.3)
       typia: 6.3.1(typescript@5.3.3)


### PR DESCRIPTION
- 기존 `요약은 플레이어에게 보이지 않습니다.` 안내 메시지 삭제
![image](https://github.com/user-attachments/assets/2982a61e-a28e-4707-a446-141c52bb0740)
