### PR TITLE
fix(S2): playId 오적용 수정

### DIFF
--- a/apps/game-builder/src/components/game-play/play/PlayPage.tsx
+++ b/apps/game-builder/src/components/game-play/play/PlayPage.tsx
@@ -53,7 +53,7 @@ export default function PlayPage({
     if (choiceSending) return;
     setChoiceSending(true);
     try {
-      const response = await postGamePlayChoice(gameId, choiceId);
+      const response = await postGamePlayChoice(playId, choiceId);
       if (!response.success) {
         throw new Error(response.error.message);
       }


### PR DESCRIPTION
- playId를 gameId로 잘못 사용하고 있는 코드 수정
- 추가 개선사항: Id 오적용을 막기 위해서 파라미터를 number 타입으로만 받지 말고, 객체 형태로 받아 각 id를 구분할 수 있도록 리팩토링 고려할 것