### PR TITLE
fix(S1): ToastUI onChange 오류 수정

### DIFF
--- a/apps/game-builder/src/components/common/BackgroundWapper.tsx
+++ b/apps/game-builder/src/components/common/BackgroundWapper.tsx
@@ -11,7 +11,7 @@ export default function BackgroundWapper({
     <div className="relative w-full h-full">
       <Image
         src={texture.src}
-        sizes="100vw"
+        sizes="(max-width: 640px) 100vw, 640px"
         alt="Background Texture"
         fill
         style={{ objectFit: "cover" }}

--- a/apps/game-builder/src/components/common/editor/Editor.tsx
+++ b/apps/game-builder/src/components/common/editor/Editor.tsx
@@ -1,15 +1,46 @@
 import { type ForwardedRef } from "react";
 import {
   Editor as ToastUiEditor,
-  type EditorProps,
+  type EditorProps as ToastUiEditorProps,
 } from "@toast-ui/react-editor";
 // eslint-disable-next-line import/no-unresolved -- @toast-ui/editor/dist/toastui-editor.css is correctly imported but ESLint can't resolve it
 import "@toast-ui/editor/dist/toastui-editor.css";
 
-interface ToastUiEditorProps {
+interface CustomEditorProps extends ToastUiEditorProps {
   forwardedRef: ForwardedRef<ToastUiEditor>;
+  onChange?: (content: string) => void; // onChange expecting a string as content
 }
 
-export default function Editor(props: EditorProps & ToastUiEditorProps) {
-  return <ToastUiEditor {...props} ref={props.forwardedRef} />;
+export default function Editor({
+  forwardedRef,
+  onChange,
+  ...props
+}: CustomEditorProps) {
+  const getWysiwygContent = () => {
+    if (forwardedRef && typeof forwardedRef !== "function") {
+      const editorInstance = forwardedRef.current;
+      if (editorInstance) {
+        const instance = editorInstance.getInstance() as {
+          getHTML: () => string;
+        };
+        const wysiwygContent = instance.getHTML();
+        return wysiwygContent;
+      }
+    }
+    return "";
+  };
+
+  const handleOnChange = () => {
+    const content = getWysiwygContent();
+    const cleanedContent = content.trim() === "<p></p>" ? "" : content;
+    onChange && onChange(cleanedContent);
+  };
+
+  return (
+    <ToastUiEditor
+      {...props}
+      onChange={handleOnChange}
+      ref={props.forwardedRef}
+    />
+  );
 }

--- a/apps/game-builder/src/components/game/builder/newPage/NewPageModal.tsx
+++ b/apps/game-builder/src/components/game/builder/newPage/NewPageModal.tsx
@@ -38,7 +38,6 @@ export default function NewPageModal({
   };
   const {
     register,
-    watch,
     reset,
     formState: { errors },
     control,
@@ -73,6 +72,8 @@ export default function NewPageModal({
   };
 
   const contentControl = useWatch({ control, name: "content" });
+  const isEnding = useWatch({ control, name: "isEnding" });
+
   const contentMaxLengthOptions = setMaxLengthOptions(
     contentControl.length,
     MAX_LENGTH.content,
@@ -116,9 +117,7 @@ export default function NewPageModal({
           <DialogFooter className="flex flex-col gap-2">
             <div className="my-2 flex gap-2 items-center flex-1">
               <ThemedSwitch name="isEnding" control={control} />
-              <p
-                className={`mb-0 text-xs ${watch("isEnding") ? "" : "opacity-50"}`}
-              >
+              <p className={`mb-0 text-xs ${isEnding ? "" : "opacity-50"}`}>
                 엔딩 페이지
               </p>
             </div>


### PR DESCRIPTION
### 오류
watch가 아니라 useWatch로 content 접근 시에 사용자가 입력하는 값이 아니라 initialEditType인 "wysiwyg" | "markdown" 문자열 반환되는 오류

### 작업
- `Editor.tsx` 컴포넌트 onChange 추가 로직 작성
- forwardedRef.current인 editorInstance의 `getHTML()` 메소드로 wysiwyg 데이터를 넘기도록 합니다.
   - (참고: getMarkdown이 markdown 데이터)
```tsx
const getWysiwygContent = () => {
  if (forwardedRef && typeof forwardedRef !== "function") {
    const editorInstance = forwardedRef.current;
    if (editorInstance) {
      const instance = editorInstance.getInstance() as {
        getHTML: () => string;
      };
      const wysiwygContent = instance.getHTML();
      return wysiwygContent;
    }
  }
  return "";
};
```
- 또한 default 값 `<p></p>` 일 때 최초 입력 시 한글 자음/모음이 분리되는 현상 예외처리를 handleOnChange 상단에 추가 
```tsx
const handleOnChange = () => {
  const content = getWysiwygContent();
  const cleanedContent = content.trim() === "<p></p>" ? "" : content;
  onChange && onChange(cleanedContent);
};
```