### PR TITLE
fix(S2): props 실수로 ref를 잡지 못하는 점 수정

### DIFF
--- a/apps/game-builder/src/components/common/editor/Editor.tsx
+++ b/apps/game-builder/src/components/common/editor/Editor.tsx
@@ -37,10 +37,6 @@ export default function Editor({
   };
 
   return (
-    <ToastUiEditor
-      {...props}
-      onChange={handleOnChange}
-      ref={props.forwardedRef}
-    />
+    <ToastUiEditor {...props} onChange={handleOnChange} ref={forwardedRef} />
   );
 }


### PR DESCRIPTION
- 함수 props argument를 구조분해한 후, 기존 props.forwardedRef를 그대로 사용하여 current가 null인 현상 발견하여 수정했습니다.