### PR TITLE
refactor(S2): 게임 play 데이터 패칭 개선

### DIFF
--- a/apps/game-builder/src/app/(game-play)/game-play/[playId]/page.tsx
+++ b/apps/game-builder/src/app/(game-play)/game-play/[playId]/page.tsx
@@ -1,14 +1,30 @@
+import { notFound } from "next/navigation";
+import { getGameIntro } from "@/actions/game-play/getIntro";
 import GamePlay from "@/components/game-play/play/GamePlay";
 
-export interface GamePlayParams {
-  playId: string;
-}
-export interface GamePlaySearchParams {
-  gameId: string;
+export interface GamePageParams {
+  params: {
+    playId: string;
+  };
+  searchParams: {
+    gameId: string;
+  };
 }
 
-export default function Page({ params }: { params: GamePlayParams }) {
+export default async function Page({ params, searchParams }: GamePageParams) {
   const { playId } = params;
+  const { gameId } = searchParams;
 
-  return <GamePlay playId={playId} />;
+  if (!gameId) notFound();
+  const response = await getGameIntro(Number(gameId));
+
+  if (!response.success) notFound();
+
+  return (
+    <GamePlay
+      playId={Number(playId)}
+      gameId={Number(gameId)}
+      gameIntro={response.intro}
+    />
+  );
 }

--- a/apps/game-builder/src/app/(game-play)/game-play/[playId]/result/page.tsx
+++ b/apps/game-builder/src/app/(game-play)/game-play/[playId]/result/page.tsx
@@ -1,19 +1,13 @@
 import { notFound } from "next/navigation";
 import { getGameResult } from "@/actions/game-play/getGameResult";
 import { getGameIntro } from "@/actions/game-play/getIntro";
-import { GameIntro } from "@/interface/customType";
+import { type GameIntro } from "@/interface/customType";
 import GamePlayChoosenPages from "@/components/game-play/result/GamePlayChoosenPages";
 import GameRestartButton from "@/components/button/GameRestartButton";
 import GameEnrich from "@/components/game/GameEnrich";
-import { type GamePlaySearchParams, type GamePlayParams } from "../page";
+import { type GamePageParams } from "../page";
 
-export default async function Page({
-  params,
-  searchParams,
-}: {
-  params: GamePlayParams;
-  searchParams: GamePlaySearchParams;
-}) {
+export default async function Page({ params, searchParams }: GamePageParams) {
   const { playId } = params;
   const { gameId } = searchParams;
   const gameInfoResponse = await getGameResult(Number(playId));

--- a/apps/game-builder/src/components/game-play/play/GamePlay.tsx
+++ b/apps/game-builder/src/components/game-play/play/GamePlay.tsx
@@ -1,57 +1,22 @@
 "use client";
-import { useEffect, useState } from "react";
-import { notFound, useSearchParams } from "next/navigation";
-import { type GamePlayParams } from "@/app/(game-play)/game-play/[playId]/page";
 import { type GameIntro as GameIntroType } from "@/interface/customType";
-import { getGameIntro } from "@/actions/game-play/getIntro";
 import PlayInfo from "../info/PlayInfo";
 import PlayPage from "./PlayPage";
 
-export default function GameIntro({ playId }: GamePlayParams) {
-  const [gameIntroResponse, setGameIntroResponse] =
-    useState<GameIntroType | null>(null);
-  const [loading, setLoading] = useState(true);
+interface GamePlayProps {
+  playId: number;
+  gameId: number;
+  gameIntro: GameIntroType;
+}
 
-  const searchParams = useSearchParams();
-  const gameId = searchParams.get("gameId");
-
-  useEffect(() => {
-    startGame();
-
-    async function startGame() {
-      setLoading(true);
-      try {
-        const response = await getGameIntro(Number(gameId));
-        if (!response.success) throw new Error(response.error.message);
-
-        setGameIntroResponse(response.intro);
-      } catch (error) {
-        notFound();
-      } finally {
-        setLoading(false);
-      }
-    }
-  }, [gameId]);
-
-  if (loading) {
-    return null;
-  }
-
-  if (!gameIntroResponse || gameId === null) {
-    notFound();
-  }
-
-  const pageId = gameIntroResponse.play?.page.id;
+export default function GamePlay({ playId, gameId, gameIntro }: GamePlayProps) {
+  const pageId = undefined;
   return (
     <section className="relative">
       {pageId !== undefined ? (
         <>
-          <PlayInfo gameIntro={gameIntroResponse} />
-          <PlayPage
-            gameId={Number(gameId)}
-            playId={Number(playId)}
-            pageId={pageId}
-          />
+          <PlayInfo gameIntro={gameIntro} />
+          <PlayPage gameId={gameId} playId={playId} pageId={pageId} />
         </>
       ) : (
         <>게임 페이지가 존재하지 않습니다</>

--- a/apps/game-builder/src/components/game-play/play/GamePlay.tsx
+++ b/apps/game-builder/src/components/game-play/play/GamePlay.tsx
@@ -10,17 +10,12 @@ interface GamePlayProps {
 }
 
 export default function GamePlay({ playId, gameId, gameIntro }: GamePlayProps) {
-  const pageId = undefined;
+  const pageId = gameIntro.play?.page?.id;
+
   return (
     <section className="relative">
-      {pageId !== undefined ? (
-        <>
-          <PlayInfo gameIntro={gameIntro} />
-          <PlayPage gameId={gameId} playId={playId} pageId={pageId} />
-        </>
-      ) : (
-        <>게임 페이지가 존재하지 않습니다</>
-      )}
+      <PlayInfo gameIntro={gameIntro} />
+      <PlayPage gameId={gameId} playId={playId} pageId={pageId} />
     </section>
   );
 }


### PR DESCRIPTION
## 진행한 이유
- 9월 26일 저녁 10시반 회의에서 발견한 코드 문제점: 게임 play 도중 page를 패칭하기 위한 response가 2가지가 될 수도 있음
  - 게임 도중 페이지: /game-play/play/{gameId}/page/{pageId}
  - 게임 엔딩 페이지: /game-play/result/{playId}
     - 두 가지 요청의 req와 res 형태가 달라 이슈가 생길 수 있으므로, 아래 개선사항과 같이 리팩토링했습니다.
 
## 개선사항

### 1. Intro 요청을 서버 컴포넌트로 이동 - page.tsx, PlayPage.tsx

seachParams을 사용한 intro 패칭을 기존 클라이언트 컴포넌트에서 page단(서버 컴포넌트)로 올려서, 비동기 관리에 따른 코드 복잡성을 줄이고 static하게 가져올 수 있도록 함

### 2. 상태 관리 대상 변경 - PlayPage.tsx
- 기존 gamePlayResponse => 현재 page
  - gamePlayResponse: response
  - page: response에서 page 또는 endingPage를 저장할 상태
- 만약 gamePlayResponse 내의 다른 데이터가 필요하면 추가 상태를 추가할 것

### 3. startGame에서 getCurrentGame 함수를 분리 - PlayPage.tsx
- 요청 분기처리가 필요한 경우, getCurrentGame내에서 작성할 것

```tsx
useEffect(() => {
  const getCurrentGame = async (props: {
    gameId: number;
    currentPageId: number;
  }) => {
    try {
      const response = await getGamePlayPage(
        props.gameId,
        props.currentPageId
      );
      if (!response.success) {
        throw new Error(response.error.message);
      }
      response.success && setPage(response.gamePlayPage.page);
    } catch (error) {
      throw new Error("게임을 불러오는 중 오류가 발생했습니다.");
    }
  };

  function startGame() {
    setLoading(true);
    try {
      getCurrentGame({ gameId, currentPageId });
    } catch (error) {
      notFound();
    } finally {
      setLoading(false);
    }
  }

  startGame();
}, [currentPageId, gameId]);
```