### PR TITLE
refactor(S2): 엔딩 페이지 출력 관련

### DIFF
--- a/apps/game-builder/src/components/game-play/play/GamePlay.tsx
+++ b/apps/game-builder/src/components/game-play/play/GamePlay.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useRouter } from "next/navigation";
 import { type GameIntro as GameIntroType } from "@/interface/customType";
 import PlayInfo from "../info/PlayInfo";
 import PlayPage from "./PlayPage";
@@ -10,7 +11,12 @@ interface GamePlayProps {
 }
 
 export default function GamePlay({ playId, gameId, gameIntro }: GamePlayProps) {
+  const router = useRouter();
   const pageId = gameIntro.play?.page?.id;
+
+  if (!pageId) {
+    return router.push(`/game-play/start?gameId=${gameId}`);
+  }
 
   return (
     <section className="relative">

--- a/apps/game-builder/src/components/game-play/play/GamePlay.tsx
+++ b/apps/game-builder/src/components/game-play/play/GamePlay.tsx
@@ -15,7 +15,7 @@ export default function GamePlay({ playId, gameId, gameIntro }: GamePlayProps) {
   const pageId = gameIntro.play?.page?.id;
 
   if (!pageId) {
-    return router.push(`/game-play/start?gameId=${gameId}`);
+    router.push(`/game-play/start?gameId=${gameId}`);
   }
 
   return (

--- a/apps/game-builder/src/components/game-play/play/PlayChoices.tsx
+++ b/apps/game-builder/src/components/game-play/play/PlayChoices.tsx
@@ -3,19 +3,20 @@ import Image from "next/image";
 import { motion } from "framer-motion";
 import { TextAlignTopIcon } from "@radix-ui/react-icons";
 import type { ApiChoice } from "@/interface/customType";
+import type useGamePlay from "@/hooks/useGamePlay";
 import penIcon from "@asset/icon/pen.png";
 
 interface PlayPageProps {
   choiceSending: boolean;
   choices: ApiChoice[];
-  handleChoiceClick: (choiceId: number) => void;
+  selectChoice: ReturnType<typeof useGamePlay>["selectChoice"];
   pageLength: number;
 }
 
 export default function PlayChoices({
   choiceSending,
   choices,
-  handleChoiceClick,
+  selectChoice,
   pageLength,
 }: PlayPageProps) {
   const [skip, setSkip] = useState(false);
@@ -24,10 +25,7 @@ export default function PlayChoices({
   return (
     <>
       {skip ? (
-        <StaticChoices
-          choices={choices}
-          handleChoiceClick={handleChoiceClick}
-        />
+        <StaticChoices choices={choices} selectChoice={selectChoice} />
       ) : (
         <>
           <motion.div
@@ -76,7 +74,7 @@ export default function PlayChoices({
                   <button
                     type="button"
                     className="text-left"
-                    onClick={() => handleChoiceClick(choice.id)}
+                    onClick={() => selectChoice({ choiceId: choice.id })}
                   >
                     {choice.description}
                   </button>
@@ -92,10 +90,10 @@ export default function PlayChoices({
 
 function StaticChoices({
   choices,
-  handleChoiceClick,
+  selectChoice,
 }: {
   choices: ApiChoice[];
-  handleChoiceClick: (choiceId: number) => void;
+  selectChoice: ReturnType<typeof useGamePlay>["selectChoice"];
 }) {
   return (
     <>
@@ -113,7 +111,7 @@ function StaticChoices({
             <button
               type="button"
               className="text-left"
-              onClick={() => handleChoiceClick(choice.id)}
+              onClick={() => selectChoice({ choiceId: choice.id })}
             >
               {choice.description}
             </button>

--- a/apps/game-builder/src/components/game-play/play/PlayPage.tsx
+++ b/apps/game-builder/src/components/game-play/play/PlayPage.tsx
@@ -1,10 +1,7 @@
 import { useEffect, useState } from "react";
 import { notFound } from "next/navigation";
-import type { GamePlayPage } from "@/interface/customType";
-import { getGamePlayPage } from "@/actions/game-play/getGamePlayPage";
-import { postGamePlayChoice } from "@/actions/game-play/postGamePlayChoice";
-import { getGameResult } from "@/actions/game-play/getGameResult";
 import TypingHtml from "@/components/common/text/TypingHtml";
+import useGamePlay from "@/hooks/useGamePlay";
 import PlayChoices from "./PlayChoices";
 import EndingPageButtonBox from "./EndingPageButtonBox";
 
@@ -17,59 +14,26 @@ export default function PlayPage({
   playId: number;
   pageId: number;
 }) {
-  const [currentPageId, setCurrentPageId] = useState(pageId);
-  const [page, setPage] = useState<GamePlayPage["page"] | null>(null);
   const [loading, setLoading] = useState(true);
-  const [choiceSending, setChoiceSending] = useState(false);
+
+  const {
+    page,
+    currentPageId,
+    choiceSending,
+    isEnding,
+    getCurrentPage,
+    getEndingPage,
+    selectChoice,
+  } = useGamePlay({
+    pageId,
+    playId,
+  });
 
   useEffect(() => {
-    const getCurrentPage = async (props: {
-      gameId: number;
-      currentPageId: number;
-    }) => {
-      try {
-        const response = await getGamePlayPage(
-          props.gameId,
-          props.currentPageId
-        );
-
-        if (!response.success) {
-          throw new Error(response.error.message);
-        }
-        if (!response.gamePlayPage.page) {
-          return false;
-        }
-
-        response.success && setPage(response.gamePlayPage.page);
-      } catch (error) {
-        throw new Error("게임을 불러오는 중 오류가 발생했습니다.");
-      }
-      return true;
-    };
-
-    const getEndingPage = async (props: { playId: number }) => {
-      try {
-        const response = await getGameResult(props.playId);
-        if (!response.success) {
-          throw new Error(response.error.message);
-        }
-        response.success &&
-          setPage({
-            id: response.result.endingPage.id,
-            description: response.result.endingPage.abridgement,
-            tempDescription: "",
-            choices: [],
-            isEnding: true,
-          });
-      } catch (error) {
-        throw new Error("게임을 불러오는 중 오류가 발생했습니다.");
-      }
-    };
-
     async function gamePlay() {
       setLoading(true);
       try {
-        const success = getCurrentPage({ gameId, currentPageId });
+        const success = await getCurrentPage({ gameId, currentPageId });
         !success && getEndingPage({ playId });
       } catch (error) {
         notFound();
@@ -79,7 +43,7 @@ export default function PlayPage({
     }
 
     gamePlay();
-  }, [currentPageId, gameId]);
+  }, [currentPageId, gameId, getCurrentPage, getEndingPage, playId]);
 
   if (loading || (loading && !page)) {
     return null;
@@ -87,25 +51,6 @@ export default function PlayPage({
   if (!page) {
     return <>페이지가 존재하지 않습니다.</>;
   }
-
-  const handleChoiceClick = async (choiceId: number) => {
-    if (choiceSending) return;
-    setChoiceSending(true);
-    try {
-      const response = await postGamePlayChoice(playId, choiceId);
-      if (!response.success) {
-        throw new Error(response.error.message);
-      }
-      const nextPageId = response.gamePlay.page?.id;
-      nextPageId && setCurrentPageId(nextPageId);
-    } catch (error) {
-      return notFound();
-    } finally {
-      setChoiceSending(false);
-    }
-  };
-
-  const isEnding = page.isEnding;
 
   if (isEnding) {
     return (
@@ -129,7 +74,7 @@ export default function PlayPage({
       <PlayChoices
         choiceSending={choiceSending}
         choices={page.choices}
-        handleChoiceClick={handleChoiceClick}
+        selectChoice={selectChoice}
         pageLength={page.description.length}
       />
     </>

--- a/apps/game-builder/src/hooks/useGamePlay.ts
+++ b/apps/game-builder/src/hooks/useGamePlay.ts
@@ -1,0 +1,86 @@
+import { useRef, useState } from "react";
+import { notFound } from "next/navigation";
+import type { GamePlayPage } from "@/interface/customType";
+import { getGamePlayPage } from "@/actions/game-play/getGamePlayPage";
+import { postGamePlayChoice } from "@/actions/game-play/postGamePlayChoice";
+import { getGameResult } from "@/actions/game-play/getGameResult";
+
+interface UseGamePlayProps {
+  pageId: number;
+  playId: number;
+}
+
+export default function useGamePlay({ pageId, playId }: UseGamePlayProps) {
+  const [currentPageId, setCurrentPageId] = useState(pageId);
+  const [page, setPage] = useState<GamePlayPage["page"] | null>(null);
+  const [choiceSending, setChoiceSending] = useState(false);
+  const playIdRef = useRef(playId);
+  const isEnding = page?.isEnding;
+
+  const getCurrentPage = async (props: {
+    gameId: number;
+    currentPageId: number;
+  }) => {
+    try {
+      const response = await getGamePlayPage(props.gameId, props.currentPageId);
+
+      if (!response.success) {
+        throw new Error(response.error.message);
+      }
+      if (!response.gamePlayPage.page) {
+        return false;
+      }
+
+      response.success && setPage(response.gamePlayPage.page);
+    } catch (error) {
+      throw new Error("게임을 불러오는 중 오류가 발생했습니다.");
+    }
+    return true;
+  };
+
+  const getEndingPage = async (props: { playId: number }) => {
+    try {
+      const response = await getGameResult(props.playId);
+      if (!response.success) {
+        throw new Error(response.error.message);
+      }
+      response.success &&
+        setPage({
+          id: response.result.endingPage.id,
+          description: response.result.endingPage.abridgement,
+          tempDescription: "",
+          choices: [],
+          isEnding: true,
+        });
+    } catch (error) {
+      throw new Error("게임을 불러오는 중 오류가 발생했습니다.");
+    }
+  };
+
+  const selectChoice = async ({ choiceId }: { choiceId: number }) => {
+    if (choiceSending) return;
+    setChoiceSending(true);
+    try {
+      const response = await postGamePlayChoice(playIdRef.current, choiceId);
+      if (!response.success) {
+        throw new Error(response.error.message);
+      }
+      const nextPageId = response.gamePlay.page?.id;
+      nextPageId && setCurrentPageId(nextPageId);
+    } catch (error) {
+      return notFound();
+    } finally {
+      setChoiceSending(false);
+    }
+  };
+
+  return {
+    page,
+    currentPageId,
+    choiceSending,
+    isEnding,
+    getCurrentPage,
+    getEndingPage,
+    selectChoice,
+  };
+}

--- a/apps/game-builder/src/hooks/useGamePlay.ts
+++ b/apps/game-builder/src/hooks/useGamePlay.ts
@@ -47,7 +47,9 @@ export default function useGamePlay({ pageId, playId }: UseGamePlayProps) {
       response.success &&
         setPage({
           id: response.result.endingPage.id,
-          description: response.result.endingPage.abridgement,
+          description:
+            response.result.endingPage.description ??
+            response.result.endingPage.abridgement,
           tempDescription: "",
           choices: [],
           isEnding: true,

--- a/apps/game-builder/src/interface/customType.ts
+++ b/apps/game-builder/src/interface/customType.ts
@@ -151,6 +151,7 @@ export interface GameResult {
   endingPage: {
     id: number;
     abridgement: string;
+    description: string;
   };
   choosenPages: ChoosenPage[];
 }


### PR DESCRIPTION
## 다음 사항 반영
- game-play page 요청이 실패 했을 때, 엔딩 결과 요청을 보내서 endingPage를 대신 사용할 것
- pageId가 없을 때, start 페이지로 리디렉션하여 게임 생성 후 다시 돌아오도록 할 것

## 커스텀훅 분리

- 사이드 이펙트를 제외한 로직을 컴포넌트 내부에서 useGamePlay.ts 커스텀훅으로 이동

## 후속 작업
- endingPage에 description이 추가되면 Nullish 연산자 지울 것
```tsx
description:
    response.result.endingPage.description ??
    response.result.endingPage.abridgement,
```