### PR TITLE
fix(S1): 에디터 최초 한글입력 시 발생하는 오류 재수정

### DIFF
--- a/apps/game-builder/src/components/common/editor/Editor.tsx
+++ b/apps/game-builder/src/components/common/editor/Editor.tsx
@@ -33,8 +33,7 @@ export default function Editor({
 
   const handleOnChange = () => {
     const content = getWysiwygContent();
-    const cleanedContent =
-      content.trim() === emptyInitialValue ? emptyInitialValue : content;
+    const cleanedContent = content.trim() === emptyInitialValue ? "" : content;
     onChange && onChange(cleanedContent);
   };
 

--- a/apps/game-builder/src/components/common/editor/Editor.tsx
+++ b/apps/game-builder/src/components/common/editor/Editor.tsx
@@ -33,8 +33,7 @@ export default function Editor({
 
   const handleOnChange = () => {
     const content = getWysiwygContent();
-    const cleanedContent = content.trim() === emptyInitialValue ? "" : content;
-    onChange && onChange(cleanedContent);
+    onChange && onChange(content);
   };
 
   return (

--- a/apps/game-builder/src/components/common/editor/contant.ts
+++ b/apps/game-builder/src/components/common/editor/contant.ts
@@ -1,1 +1,4 @@
 export const emptyInitialValue = "<p></p>";
+const emptyValues = ["", emptyInitialValue, "<p><br></p>"];
+
+export const isValueEmpty = (value: string) => emptyValues.includes(value);

--- a/apps/game-builder/src/components/game/builder/newPage/NewPageModal.tsx
+++ b/apps/game-builder/src/components/game/builder/newPage/NewPageModal.tsx
@@ -16,7 +16,10 @@ import MaxLengthText, {
   setMaxLengthOptions,
 } from "@/components/common/form/MaxLengthText";
 import PageContentEditor from "@/components/common/editor/PageContentEditor";
-import { emptyInitialValue } from "@/components/common/editor/contant";
+import {
+  emptyInitialValue,
+  isValueEmpty,
+} from "@/components/common/editor/contant";
 
 interface NewPageModalProps extends ReturnType<typeof useForm<NewPage>> {
   handleNewPage: (newPageData: { content: string; isEnding: boolean }) => void;
@@ -53,7 +56,7 @@ export default function NewPageModal({
   const handleButtonClick = async () => {
     const isValid = await trigger();
     const { content } = getValues();
-    if (emptyInitialValue === content) {
+    if (isValueEmpty(content)) {
       setError("content", {
         type: "required",
         message: "페이지 내용을 입력해주세요",

--- a/apps/game-builder/src/components/game/confirm/ConfirmGame.tsx
+++ b/apps/game-builder/src/components/game/confirm/ConfirmGame.tsx
@@ -5,6 +5,7 @@ import { useForm } from "react-hook-form";
 import type { UpdateGameReqDto } from "@choosetale/nestia-type/lib/structures/UpdateGameReqDto";
 import type { GameInfo } from "@/interface/customType";
 import { updateGame } from "@/actions/game/updateGame";
+import { isValueEmpty } from "@/components/common/editor/contant";
 import NextButton from "@components/button/SubmitButton";
 import GameConfirmFields from "@/components/game/confirm/form/GameConfirmFields";
 
@@ -22,11 +23,20 @@ export default function ConfirmGame({
       thumbnailImageId: gameInfoData.thumbnails[0]?.id ?? -1,
     },
   });
-  const { handleSubmit, watch } = useFormProps;
+  const { handleSubmit, watch, setError } = useFormProps;
 
   const onSubmit: SubmitHandler<GameInfo> = async (fieldValues) => {
     const { title, description, genre, isPrivate, thumbnailImageId } =
       fieldValues;
+
+    if (isValueEmpty(description)) {
+      setError("description", {
+        type: "required",
+        message: "페이지 내용을 입력해주세요",
+      });
+      return;
+    }
+
     const payload: UpdateGameReqDto = {
       title,
       description,

--- a/apps/game-builder/src/components/game/confirm/form/GameConfirmFields.tsx
+++ b/apps/game-builder/src/components/game/confirm/form/GameConfirmFields.tsx
@@ -96,7 +96,7 @@ export default function GameConfirmFields({
         />
       </div>
 
-      <div className="flex flex-col sm:!flex-row gap-2">
+      <div className="flex flex-col sm:!flex-row gap-2 pt-2">
         <div className="flex gap-2 items-center">
           <p className="mb-0 text-xs">게임을 비공개로 올릴까요?</p>
           <ThemedSwitch name="isPrivate" control={control} />


### PR DESCRIPTION
### emptyInitialValue 관련 2가지 오류 케이스
- emptyInitialValue가 없으면? placeholder가 아니라, 아래와 같은 텍스트가 출력된다. - ToastUI 초기값 이슈
![image](https://github.com/user-attachments/assets/0d60af08-1de1-4b5d-a09b-f8a6b24b7ee2)
- onChange에서 emptyInitialValue를 덮어쓸 시, 한글 입력의 자음/모음이 분리되어 출력된다. - wysiwyg 기본값 상태관리 이슈
![image](https://github.com/user-attachments/assets/a6a593a1-fd0f-418f-85ec-9221a25616c9)

### isValueEmpty 추가

- onSubmit 혹은 새 페이지 작성 시, 초기값 확인 후 얼리 리턴을 위해 사용할 유틸 함수 추가
```tsx
export const emptyInitialValue = "<p></p>"; // 기존 사용하던 초기값 
const emptyValues = ["", emptyInitialValue, "<p><br></p>"]; // 초기값 "<p></p>"에 사용자가 값을 입력했다가 삭제하는 경우 "<p><br></p>"

export const isValueEmpty = (value: string) => emptyValues.includes(value); // boolean 반환
```

### Editor.tsx 내 onChange 정리
```tsx
const handleOnChange = () => {
  const content = getWysiwygContent();
  onChange && onChange(content);
};

return (
  <ToastUiEditor
    {...props}
    initialValue={props.initialValue || emptyInitialValue}
    onChange={handleOnChange}
    ref={forwardedRef}
  />
);
```