### PR TITLE
feat(S3): 게임 목록 페이지 기본 출력

### DIFF
--- a/apps/game-builder/src/actions/list/getGameList.ts
+++ b/apps/game-builder/src/actions/list/getGameList.ts
@@ -1,0 +1,38 @@
+"use server";
+import type { HttpError } from "@choosetale/nestia-type";
+import { API_URL } from "@/config/config";
+import type { GameList } from "@/interface/customType";
+import type { ApiResponse, SuccessResponse } from "../action";
+
+interface ApiSuccessResponse extends SuccessResponse {
+  gameList: GameList;
+}
+
+export const getGameList = async ({
+  page,
+  limit,
+  genre,
+  sort,
+}: {
+  page: number;
+  limit: number;
+  genre: string;
+  sort: string;
+}): Promise<ApiResponse<ApiSuccessResponse>> => {
+  const url = `${API_URL}/game-play/list?page=${page}&limit=${limit}&genre=${genre}&sort=${sort}`;
+
+  try {
+    const response = await fetch(url, {
+      method: "GET",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      mode: "no-cors",
+    });
+
+    const data = (await response.json()) as GameList;
+    return { success: true, gameList: data };
+  } catch (error) {
+    return { success: false, error: error as HttpError };
+  }
+};

--- a/apps/game-builder/src/app/(game-list)/list/page.tsx
+++ b/apps/game-builder/src/app/(game-list)/list/page.tsx
@@ -1,0 +1,31 @@
+import { Suspense } from "react";
+import { getGameList } from "@/actions/list/getGameList";
+import GameList from "@/components/game-list/GameList";
+
+export interface GameListParams {
+  searchParams: {
+    page: string;
+    genre: string;
+    sort: string;
+  };
+}
+
+export default async function Page({ searchParams }: GameListParams) {
+  const params = {
+    page: Number(searchParams.page) || 1,
+    limit: 10,
+    genre: searchParams.genre,
+    sort: searchParams.sort || "desc",
+  };
+  const response = await getGameList(params);
+
+  if (!response.success) {
+    throw new Error("Failed to fetch game list");
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <GameList gameList={response.gameList} />
+    </Suspense>
+  );
+}

--- a/apps/game-builder/src/app/(game-list)/list/page.tsx
+++ b/apps/game-builder/src/app/(game-list)/list/page.tsx
@@ -1,23 +1,20 @@
 import { Suspense } from "react";
 import { getGameList } from "@/actions/list/getGameList";
+import {
+  formatGameListSearchParams,
+  type GameListSearchParams,
+} from "@/utils/formatGameListSearchParams";
 import GameList from "@/components/game-list/GameList";
 
+export const dynamic = "force-dynamic";
+
 export interface GameListParams {
-  searchParams: {
-    page: string;
-    genre: string;
-    sort: string;
-  };
+  searchParams: GameListSearchParams;
 }
 
 export default async function Page({ searchParams }: GameListParams) {
-  const params = {
-    page: Number(searchParams.page) || 1,
-    limit: 10,
-    genre: searchParams.genre,
-    sort: searchParams.sort || "desc",
-  };
-  const response = await getGameList(params);
+  const formattedParams = formatGameListSearchParams(searchParams);
+  const response = await getGameList(formattedParams);
 
   if (!response.success) {
     throw new Error("Failed to fetch game list");
@@ -25,7 +22,7 @@ export default async function Page({ searchParams }: GameListParams) {
 
   return (
     <Suspense fallback={null}>
-      <GameList gameList={response.gameList} />
+      <GameList firstList={response.gameList} />
     </Suspense>
   );
 }

--- a/apps/game-builder/src/app/[lang]/dictionaries/en.json
+++ b/apps/game-builder/src/app/[lang]/dictionaries/en.json
@@ -1,5 +1,6 @@
 {
   "genre": {
+    "ALL": "All",
     "FANTASY": "Fantasy",
     "SCI_FI": "Science Fiction",
     "HORROR": "Horror",

--- a/apps/game-builder/src/app/[lang]/dictionaries/ko.json
+++ b/apps/game-builder/src/app/[lang]/dictionaries/ko.json
@@ -1,5 +1,6 @@
 {
   "genre": {
+    "ALL": "전체",
     "FANTASY": "판타지",
     "SCI_FI": "공상 과학",
     "HORROR": "공포",

--- a/apps/game-builder/src/components/game-list/GameList.tsx
+++ b/apps/game-builder/src/components/game-list/GameList.tsx
@@ -1,0 +1,12 @@
+import { type GameList as GameListType } from "@/interface/customType";
+import GameListCard from "./GameListCard";
+
+export default function GameList({ gameList }: { gameList: GameListType }) {
+  return (
+    <>
+      {gameList.map((e) => (
+        <GameListCard gameData={e} key={e.game.id} />
+      ))}
+    </>
+  );
+}

--- a/apps/game-builder/src/components/game-list/GameList.tsx
+++ b/apps/game-builder/src/components/game-list/GameList.tsx
@@ -1,12 +1,61 @@
+"use client";
+import { useEffect, useState, useMemo } from "react";
+import { useSearchParams } from "next/navigation";
 import { type GameList as GameListType } from "@/interface/customType";
+import { getGameList } from "@/actions/list/getGameList";
+import {
+  type GameListSearchParams,
+  formatGameListSearchParams,
+} from "@/utils/formatGameListSearchParams";
 import GameListCard from "./GameListCard";
+import GameListFilters from "./GameListFilters";
 
-export default function GameList({ gameList }: { gameList: GameListType }) {
+export default function GameList({ firstList }: { firstList: GameListType }) {
+  const searchParams = useSearchParams();
+  const [gameList, setGameList] = useState<GameListType>(firstList);
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const formattedSearchParams = useMemo(() => {
+    const params = Object.fromEntries(
+      searchParams
+    ) as unknown as GameListSearchParams;
+    return formatGameListSearchParams(params);
+  }, [searchParams]);
+
+  useEffect(() => {
+    const fetchGameList = async () => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await getGameList(formattedSearchParams);
+        if (response.success) {
+          setGameList(response.gameList);
+        } else {
+          throw new Error("Failed to fetch game list");
+        }
+      } catch (err) {
+        setError("An error occurred while fetching the game list.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchGameList();
+  }, [formattedSearchParams]);
+
+  if (error) {
+    return <p>{error}</p>;
+  }
+
   return (
     <>
+      <GameListFilters searchParams={searchParams.toString()} />
       {gameList.map((e) => (
         <GameListCard gameData={e} key={e.game.id} />
       ))}
+      {loading && <p className="text-center">Loading...</p>}
     </>
   );
 }

--- a/apps/game-builder/src/components/game-list/GameListCard.tsx
+++ b/apps/game-builder/src/components/game-list/GameListCard.tsx
@@ -1,0 +1,10 @@
+import { type GameListGame } from "@/interface/customType";
+
+export default function GameListCard({ gameData }: { gameData: GameListGame }) {
+  return (
+    <div className="border border-black p-10 m-10">
+      <p>{gameData.game.title}</p>
+      <p>{gameData.publisher.nickname}</p>
+    </div>
+  );
+}

--- a/apps/game-builder/src/components/game-list/GameListFilters.tsx
+++ b/apps/game-builder/src/components/game-list/GameListFilters.tsx
@@ -1,0 +1,17 @@
+import GameListGenresSelect from "./GameListGenresSelect";
+import GameListSort from "./GameListSort";
+
+interface FilterComponentProps {
+  searchParams: string;
+}
+
+export default function GameListFilters({
+  searchParams,
+}: FilterComponentProps) {
+  return (
+    <div className="flex items-center gap-4 justify-end">
+      <GameListGenresSelect searchParams={searchParams} />
+      <GameListSort searchParams={searchParams} />
+    </div>
+  );
+}

--- a/apps/game-builder/src/components/game-list/GameListGenresSelect.tsx
+++ b/apps/game-builder/src/components/game-list/GameListGenresSelect.tsx
@@ -1,0 +1,62 @@
+import { useCallback, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useForm, useWatch } from "react-hook-form";
+import { type Genres } from "@choosetale/nestia-type/lib/structures/Genres";
+import { type GameInfo } from "@/interface/customType";
+import GenresSelect from "../game/confirm/form/GenresSelect";
+
+interface GameListGenresSelectProps {
+  searchParams: string;
+}
+
+const createParams = (paramsString: string) =>
+  new URLSearchParams(paramsString);
+
+export default function GameListGenresSelect({
+  searchParams,
+}: GameListGenresSelectProps) {
+  const router = useRouter();
+  const params = createParams(searchParams);
+
+  const defaultValues = { genre: (params.get("genre") as Genres) || "all" };
+  const { control } = useForm<Partial<GameInfo>>({
+    defaultValues,
+  });
+  const genre = useWatch({ control, name: "genre" });
+
+  const handleFilterChange = useCallback(
+    (newGenre: string) => {
+      const updatedParams = createParams(searchParams);
+      const newGenreLowerCase = newGenre.toLowerCase();
+
+      if (newGenreLowerCase === "all") {
+        updatedParams.delete("genre");
+      } else {
+        updatedParams.set("genre", newGenreLowerCase);
+      }
+      router.push(`?${updatedParams.toString()}`);
+    },
+    [searchParams, router]
+  );
+
+  useEffect(() => {
+    if (genre) {
+      handleFilterChange(genre);
+    }
+  }, [genre, handleFilterChange]);
+
+  const sortId = "genresSelect";
+
+  return (
+    <>
+      <label htmlFor={sortId}>장르</label>
+      <GenresSelect
+        id={sortId}
+        name="genre"
+        labelText=""
+        control={control}
+        hasSelectAll
+      />
+    </>
+  );
+}

--- a/apps/game-builder/src/components/game-list/GameListSort.tsx
+++ b/apps/game-builder/src/components/game-list/GameListSort.tsx
@@ -1,0 +1,36 @@
+import { useRouter } from "next/navigation";
+
+export default function GameListSort({
+  searchParams,
+}: {
+  searchParams: string;
+}) {
+  const router = useRouter();
+
+  const createParams = (paramsString: string) =>
+    new URLSearchParams(paramsString);
+  const params = createParams(searchParams);
+  const defaultSort = "desc";
+
+  const handleSortChange = (newSortOrder: "asc" | "desc") => {
+    const updatedParams = createParams(searchParams);
+    updatedParams.set("sort", newSortOrder);
+    router.push(`?${updatedParams.toString()}`);
+  };
+
+  const sortId = "sortSelect";
+
+  return (
+    <>
+      <label htmlFor={sortId}>정렬</label>
+      <select
+        id={sortId}
+        value={params.get("sort") || defaultSort}
+        onChange={(e) => handleSortChange(e.target.value as "asc" | "desc")}
+      >
+        <option value="asc">오래된 순</option>
+        <option value="desc">최신 순</option>
+      </select>
+    </>
+  );
+}

--- a/apps/game-builder/src/components/game/confirm/form/GameConfirmFields.tsx
+++ b/apps/game-builder/src/components/game/confirm/form/GameConfirmFields.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useWatch, type useForm } from "react-hook-form";
+import { useWatch, type useForm, type Control } from "react-hook-form";
 import { InfoCircledIcon, Pencil1Icon } from "@radix-ui/react-icons";
 import ThemedInputField from "@themed/ThemedInputField";
 import ThemedSwitch from "@themed/ThemedSwitch";
@@ -84,7 +84,11 @@ export default function GameConfirmFields({
 
       <Thumbnails {...useFormProps} />
 
-      <GenresSelect name="genre" labelText="게임 장르" control={control} />
+      <GenresSelect
+        name="genre"
+        labelText="게임 장르"
+        control={control as Control<Partial<GameInfo>>}
+      />
 
       <MaxLengthText {...descriptionMaxLengthOptions} className="top-0" />
       <div className="h-[20vh] bg-gray-100">

--- a/apps/game-builder/src/components/game/confirm/form/GenresSelect.tsx
+++ b/apps/game-builder/src/components/game/confirm/form/GenresSelect.tsx
@@ -1,6 +1,6 @@
-import { forwardRef } from "react";
 import type { Control } from "react-hook-form";
 import { Controller } from "react-hook-form";
+import { type Genres } from "@choosetale/nestia-type/lib/structures/Genres";
 import type { InputProps } from "@repo/ui/components/ui/Input.jsx";
 import {
   Select,
@@ -9,50 +9,56 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@repo/ui/components/ui/Select.tsx";
-import type { GameInfo } from "@/interface/customType";
 import { GENRES } from "@/constants/genres";
-import ThemedLabel from "@/components/theme/ui/ThemedLabel";
+import type { GameInfo } from "@/interface/customType";
 import { useTranslation } from "@/hooks/useTranslation";
+import ThemedLabel from "@/components/theme/ui/ThemedLabel";
 
 interface GenresSelectProps extends InputProps {
   labelText: string;
-  name: keyof GameInfo;
-  control: Control<GameInfo>;
+  name: keyof Partial<GameInfo>;
+  control: Control<Partial<GameInfo>>;
+  hasSelectAll?: boolean;
 }
 
-const GenresSelect = forwardRef<HTMLSelectElement, GenresSelectProps>(
-  ({ labelText, name, control, ...props }) => {
-    const { t } = useTranslation();
+export default function GenresSelect({
+  labelText,
+  name,
+  control,
+  hasSelectAll = false,
+  ...props
+}: GenresSelectProps) {
+  const { t } = useTranslation();
+  let genres: (Genres | "ALL")[] = GENRES;
 
-    return (
-      <div className="flex flex-col gap-2">
-        <ThemedLabel labelText={labelText} />
-        <Controller
-          name={name}
-          control={control}
-          render={({ field }) => (
-            <Select
-              onValueChange={field.onChange}
-              value={field.value ? String(field.value) : ""}
-            >
-              <SelectTrigger className="!text-xs !w-full bg-white">
-                <SelectValue placeholder={props.value} />
-              </SelectTrigger>
-              <SelectContent>
-                {GENRES.map((genre) => (
-                  <SelectItem key={genre} value={genre}>
-                    {t(`genre.${genre}`)}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          )}
-        />
-      </div>
-    );
+  if (hasSelectAll) {
+    genres = ["ALL", ...genres];
   }
-);
 
-GenresSelect.displayName = "GenresSelect";
-
-export default GenresSelect;
+  return (
+    <div className="flex flex-col gap-2">
+      <ThemedLabel labelText={labelText} />
+      <Controller
+        name={name}
+        control={control}
+        render={({ field }) => (
+          <Select
+            onValueChange={field.onChange}
+            value={field.value ? String(field.value).toLocaleUpperCase() : ""}
+          >
+            <SelectTrigger className="!text-xs !w-full bg-white">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent id={props.id}>
+              {genres.map((genre) => (
+                <SelectItem key={genre} value={genre}>
+                  {t(`genre.${genre}`)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        )}
+      />
+    </div>
+  );
+}

--- a/apps/game-builder/src/interface/customType.ts
+++ b/apps/game-builder/src/interface/customType.ts
@@ -155,3 +155,36 @@ export interface GameResult {
   };
   choosenPages: ChoosenPage[];
 }
+
+export interface GameListGame {
+  game: {
+    id: number;
+    title: string;
+    thumbnail: {
+      id: number;
+      url: string;
+    };
+    genre: string;
+    createdAt: string;
+    updatedAt: string;
+  };
+  publisher: {
+    userId: number;
+    nickname: string;
+    profileImage: {
+      url: string;
+    };
+  };
+  enrichData: {
+    totalEndingCount: number;
+    totalRechedEndingPlayCount: number;
+    expectPlayTime: number;
+    me: {
+      isExistReachedEndingPlay: boolean;
+      reachedEndingPlayCount: number;
+      isExistContinuePlay: boolean;
+    };
+  };
+}
+
+export type GameList = GameListGame[];

--- a/apps/game-builder/src/utils/formatGameListSearchParams.ts
+++ b/apps/game-builder/src/utils/formatGameListSearchParams.ts
@@ -1,0 +1,18 @@
+export interface GameListSearchParams {
+  page: string;
+  genre: string;
+  sort?: string;
+}
+
+export const formatGameListSearchParams = (
+  searchParams: GameListSearchParams
+) => {
+  const defaultLimit = 10;
+
+  return {
+    page: Number(searchParams.page) || 1,
+    limit: defaultLimit,
+    genre: searchParams.genre,
+    sort: searchParams.sort || "desc",
+  };
+};


### PR DESCRIPTION
## 게임 목록 페이지 기본 출력
![image](https://github.com/user-attachments/assets/b3a3772c-c70e-463a-9bff-170592f57c39)

### `game-play/list` api의 mocking response를 사용하여 게임 목록 페이지 작성
- CSS를 제외한 기능 구현
- 일요일 10시 회의 이후 디자인 업데이트 예정
### 2가지 필터: GameListFilters.tsx 내부에 각 필터 컴포넌트 위치
- GameListGenresSelect.tsx: 기존 /confirm 페이지의 select를 재사용하기 위해 react-hook-form control 사용
- GameListSort.tsx: onChange를 사용한 uncontrolled 컴포넌트
### 영어/한글 다국어 파일에 genre.all 텍스트 추가
- 현재 api의 genre가 required이기 때문에 아래 사항 문의 중
  - genre를 선택하지 않았을 때(all일 때): genres를 ,로 구분하는 식으로 전체를 보내야 하는지? 또는 all과 같은 값이 있는지?

---

### 후속 작업
- 무한 스크롤
- 스크롤 높이 유지
- 5분마다 데이터 갱신
- Pull-to-Refresh 
