### PR TITLE
feat(S4): 랜딩 페이지 로직 수정

### DIFF
--- a/apps/game-builder/src/app/(game-list)/list/_components/GameList.tsx
+++ b/apps/game-builder/src/app/(game-list)/list/_components/GameList.tsx
@@ -55,9 +55,9 @@ export default function GameList({ firstList }: { firstList: GameListType }) {
           page: pageNum,
           limit: LIMIT_AFTER_PAGE_ONE,
         });
-        const responseGameList = response.success && response.gameList;
+        const responseGameList = response.data;
 
-        if (responseGameList && responseGameList.length) {
+        if (responseGameList?.length) {
           setGameList((prevList) => [...prevList, ...responseGameList]);
           if (responseGameList.length < LIMIT_AFTER_PAGE_ONE) {
             setHasMore(false);

--- a/apps/game-builder/src/app/(oauth)/oauth/_hooks/useSocialLogin.ts
+++ b/apps/game-builder/src/app/(oauth)/oauth/_hooks/useSocialLogin.ts
@@ -1,7 +1,7 @@
 import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { signIn, signOut, useSession } from "next-auth/react";
-import { type SessionWhenLoggin } from "@/app/api/auth/[...nextauth]/route";
+import { type SessionWhenLoggin } from "@/lib/next-auth/authOptions";
 
 export default function useSocialLogin() {
   const router = useRouter();
@@ -24,7 +24,7 @@ export default function useSocialLogin() {
     if (isLoggin) {
       router.push("/list");
     }
-  }, [sessionWithCookie, router]);
+  }, [sessionWithCookie, router, isLoggin]);
 
   return {
     sessionWithCookie,

--- a/apps/game-builder/src/app/_components/AuthRedirect.ts
+++ b/apps/game-builder/src/app/_components/AuthRedirect.ts
@@ -1,0 +1,19 @@
+"use client";
+import { usePathname, useRouter } from "next/navigation";
+import { useSession } from "next-auth/react";
+
+export default function AuthRedirect() {
+  const session = useSession();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  if (session.status === "authenticated" && pathname === "/") {
+    router.push("/list");
+  } else if (session.status === "unauthenticated" && pathname !== "/oauth") {
+    document.cookie =
+      "connect.sid=; path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC;";
+    router.push("/oauth");
+  }
+
+  return null;
+}

--- a/apps/game-builder/src/app/api/auth/[...nextauth]/route.ts
+++ b/apps/game-builder/src/app/api/auth/[...nextauth]/route.ts
@@ -1,59 +1,6 @@
-import { cookies } from "next/headers";
-import NextAuth, {
-  type NextAuthOptions,
-  type Account,
-  type Session,
-} from "next-auth";
-import GoogleProvider from "next-auth/providers/google";
-import { userLogin } from "@/actions/user/userLogIn";
+import NextAuth from "next-auth";
+import { authOptions } from "@/lib/next-auth/authOptions";
 
-type AccountWhenLoggin = Account & { loggin: boolean };
-export type SessionWhenLoggin = Session & { loggin: boolean };
-
-const nextAuthOptions: NextAuthOptions = {
-  providers: [
-    GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID ?? "",
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
-    }),
-  ],
-  callbacks: {
-    async signIn({ account }) {
-      try {
-        if (account) {
-          const res = await userLogin(account);
-          if (!res.success || !res.cookie) {
-            return false;
-          }
-
-          const connectSidCookie = res.cookie[0];
-          if (connectSidCookie) {
-            cookies().set(
-              "connect.sid",
-              connectSidCookie
-                .replace("connect.sid=", "")
-                .replace("connect.sid%3D", "")
-            );
-            (account as AccountWhenLoggin).loggin = true;
-          }
-        }
-        return true;
-      } catch (error) {
-        return false;
-      }
-    },
-    jwt({ token, account }) {
-      if (account) {
-        token.loggin = account.loggin;
-      }
-      return token;
-    },
-    session({ session, token }) {
-      return { ...session, loggin: token.loggin } as SessionWhenLoggin;
-    },
-  },
-};
-
-const handler = NextAuth(nextAuthOptions);
+const handler = NextAuth(authOptions);
 
 export { handler as GET, handler as POST };

--- a/apps/game-builder/src/app/error.tsx
+++ b/apps/game-builder/src/app/error.tsx
@@ -1,7 +1,6 @@
 "use client";
 import React from "react";
-import { useRouter } from "next/navigation";
-import { usePathname } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
 import LinkedButton from "@/components/common/button/LinkedButton";
 
 interface ErrorProps {
@@ -9,7 +8,7 @@ interface ErrorProps {
   reset: () => void;
 }
 
-export default function ErrorPage({ error, reset }: ErrorProps) {
+export default function ErrorPage({ error }: ErrorProps) {
   const isAuthError = error.message.includes("401");
   const router = useRouter();
   const pathname = usePathname();
@@ -29,9 +28,7 @@ export default function ErrorPage({ error, reset }: ErrorProps) {
       description: "잠시 후 로그인 페이지로 이동합니다.",
     },
   };
-  const currentError = isAuthError
-    ? ERROR["AUTH_ERROR"]
-    : ERROR["DEFAULT_ERROR"];
+  const currentError = isAuthError ? ERROR.AUTH_ERROR : ERROR.DEFAULT_ERROR;
 
   return (
     <ErrorWrapper

--- a/apps/game-builder/src/app/layout.tsx
+++ b/apps/game-builder/src/app/layout.tsx
@@ -7,6 +7,7 @@ import CSSThemeProvider from "@/components/theme/ThemeProvider";
 import LocaleProvider from "@/components/LocaleProvider";
 import SessionProvider from "@/components/SessionProvider";
 import { getDictionary } from "./[lang]/dictionaries";
+import AuthRedirect from "./_components/AuthRedirect";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -30,7 +31,10 @@ export default async function RootLayout({
         <LocaleProvider dict={dict}>
           <CSSThemeProvider>
             <Toaster />
-            <SessionProvider>{children}</SessionProvider>
+            <SessionProvider>
+              <AuthRedirect />
+              {children}
+            </SessionProvider>
           </CSSThemeProvider>
         </LocaleProvider>
       </body>

--- a/apps/game-builder/src/app/page.tsx
+++ b/apps/game-builder/src/app/page.tsx
@@ -2,13 +2,12 @@ import BackgroundWapper from "@/components/common/BackgroundWapper";
 import MobileWrapper from "@/packages/ui/components/MobileWrapper";
 import Landing from "@/components/temp/landing/Landing";
 
-export default function Page(): JSX.Element {
+export default function Page() {
   return (
     <MobileWrapper>
       <BackgroundWapper>
         <main className="h-full flex-1 flex items-center justify-center">
           <Landing />
-          <div />
         </main>
       </BackgroundWapper>
     </MobileWrapper>

--- a/apps/game-builder/src/components/temp/landing/Landing.tsx
+++ b/apps/game-builder/src/components/temp/landing/Landing.tsx
@@ -1,6 +1,5 @@
 import Image from "next/image";
 import logo from "@/asset/logo.png";
-import LandingButtonBox from "./LandingButtonBox";
 
 export default function Landing() {
   return (
@@ -14,10 +13,6 @@ export default function Landing() {
           style={{ objectFit: "contain" }}
         />
         <h1 className="text-xl font-bold mb-6">ChooseTale</h1>
-      </div>
-
-      <div className="flex flex-col gap-3">
-        <LandingButtonBox />
       </div>
     </div>
   );

--- a/apps/game-builder/src/config/config.ts
+++ b/apps/game-builder/src/config/config.ts
@@ -1,5 +1,6 @@
 const API_URL = process.env.NEXT_PUBLIC_BACKEND_API as string;
 const SOCKET_URL = process.env.NEXT_PUBLIC_SOCKET_API as string;
 const AUTH_KEY = process.env.AUTH_KEY as string;
+const AUTH_SECRET = process.env.AUTH_SECRET as string;
 
-export { API_URL, SOCKET_URL, AUTH_KEY };
+export { API_URL, SOCKET_URL, AUTH_KEY, AUTH_SECRET };

--- a/apps/game-builder/src/lib/next-auth/authOptions.ts
+++ b/apps/game-builder/src/lib/next-auth/authOptions.ts
@@ -1,0 +1,53 @@
+import { cookies } from "next/headers";
+import { type NextAuthOptions, type Account, type Session } from "next-auth";
+import GoogleProvider from "next-auth/providers/google";
+import { userLogin } from "@/actions/user/userLogIn";
+import { AUTH_SECRET } from "@/config/config";
+
+type AccountWhenLoggin = Account & { loggin: boolean };
+export type SessionWhenLoggin = Session & { loggin: boolean };
+
+export const authOptions: NextAuthOptions = {
+  secret: AUTH_SECRET,
+  providers: [
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+    }),
+  ],
+  callbacks: {
+    async signIn({ account }) {
+      try {
+        if (account) {
+          const res = await userLogin(account);
+          if (!res.success || !res.cookie) {
+            return false;
+          }
+
+          const connectSidCookie = res.cookie[0];
+          if (connectSidCookie) {
+            cookies().set(
+              "connect.sid",
+              connectSidCookie
+                .replace("connect.sid=", "")
+                .replace("connect.sid%3D", "")
+            );
+            (account as AccountWhenLoggin).loggin = true;
+          }
+        }
+        return true;
+      } catch (error) {
+        return false;
+      }
+    },
+    jwt({ token, account }) {
+      if (account) {
+        token.loggin = account.loggin;
+      }
+      return token;
+    },
+    session({ session, token }) {
+      return { ...session, loggin: token.loggin } as SessionWhenLoggin;
+    },
+  },
+};


### PR DESCRIPTION
## 랜딩 페이지 로직 수정



- 랜딩 시 로그인 상태라면, /list로 이동
- 랜딩 시 미로그인 상태라면, 쿠키를 지우고 /oauth로 이동
- authOption 분리 (getServerSession에서 사용하는 경우를 위해서 분리했습니다. route.ts에서 export 시 린트 오류 발생해요.)

### 리디렉션


```tsx
if (session.status === "authenticated" && pathname === "/") {
  router.push("/list");
} else if (session.status === "unauthenticated" && pathname !== "/oauth") {
  document.cookie =
    "connect.sid=; path=/; expires=Thu, 01 Jan 1970 00:00:00 UTC;";
  router.push("/oauth");
}
```

### 리디렉션이 동작하기 전까지 보이는 랜딩페이지
- 기존 버튼 박스는 삭제

![image](https://github.com/user-attachments/assets/9a9a87ad-be2d-49bd-b535-78d1162f95b5)

