### PR TITLE
feat(S6): 게임 리스트 필터에 option 전달 추가

### DIFF
--- a/apps/game-builder/src/actions/my-page/getContinuedGame.ts
+++ b/apps/game-builder/src/actions/my-page/getContinuedGame.ts
@@ -6,12 +6,12 @@ export const getContinuedGame = async ({
   page,
   limit,
   genre,
-  order,
+  sort: order,
 }: {
   page: number;
   limit: number;
   genre: string;
-  order: string;
+  sort: string;
 }) => {
   const response = await api.get("/my-page/continued-game", {
     params: {

--- a/apps/game-builder/src/app/(game-list)/list/_components/game-list-filters/GameListFilters.tsx
+++ b/apps/game-builder/src/app/(game-list)/list/_components/game-list-filters/GameListFilters.tsx
@@ -1,15 +1,18 @@
 "use client";
 import { type FormattedSearchParams } from "@/utils/formatGameListSearchParams";
+import type { GameListOption } from "@/interface/customType";
 import { useUpdateSearchParams } from "@/hooks/useUpdateSearchParams";
 import GameListSort from "./GameListSort";
 import GenresFilterDraw from "./GenresFilterDraw";
 
 interface FilterComponentProps {
   searchParams: FormattedSearchParams;
+  option: GameListOption;
 }
 
 export default function GameListFilters({
   searchParams,
+  option,
 }: FilterComponentProps) {
   const { updateSearchParams } = useUpdateSearchParams();
 
@@ -27,10 +30,13 @@ export default function GameListFilters({
         searchParams={searchParams}
         handleGenreChange={handleGenreChange}
       />
-      <GameListSort
-        searchParams={searchParams}
-        handleSortChange={handleSortChange}
-      />
+      {option && (
+        <GameListSort
+          searchParams={searchParams}
+          handleSortChange={handleSortChange}
+          option={option}
+        />
+      )}
     </>
   );
 }

--- a/apps/game-builder/src/app/(game-list)/list/_components/game-list-filters/GameListSort.tsx
+++ b/apps/game-builder/src/app/(game-list)/list/_components/game-list-filters/GameListSort.tsx
@@ -1,34 +1,36 @@
 "use client";
-import { type SortType } from "@/interface/customType";
+import type { GameListOption } from "@/interface/customType";
 import { type FormattedSearchParams } from "@/utils/formatGameListSearchParams";
 
 interface GameListSelectProps {
   searchParams: FormattedSearchParams;
   handleSortChange: (newSort: string) => void;
+  option: GameListOption;
 }
 
 export default function GameListSort({
   searchParams,
   handleSortChange,
+  option,
 }: GameListSelectProps) {
   const defaultSort = searchParams.sort;
 
   const sortId = "sortSelect";
-  const sorts: { value: SortType; option: string }[] = [
-    { value: "LATEST", option: "최신순" },
-    { value: "POPULAR", option: "인기순" },
-  ];
+  const sorts = option.sorts.map((sort) => ({
+    value: sort.value,
+    optionLabel: sort.optionLabel,
+  }));
 
   return (
     <select
       id={sortId}
       value={searchParams.sort || defaultSort}
-      onChange={(e) => handleSortChange(e.target.value as SortType)}
+      onChange={(e) => handleSortChange(e.target.value)}
       className="bg-transparent body pl-2 pr-1 h-full"
     >
-      {sorts.map(({ value, option }) => (
+      {sorts.map(({ value, optionLabel }) => (
         <option key={value} value={value}>
-          {option}
+          {optionLabel}
         </option>
       ))}
     </select>

--- a/apps/game-builder/src/app/(game-list)/list/page.tsx
+++ b/apps/game-builder/src/app/(game-list)/list/page.tsx
@@ -29,7 +29,15 @@ export default async function Page({ searchParams }: GameListParams) {
     <Suspense fallback={null}>
       <div className="h-[calc(100vh-8rem)] flex flex-col mx-5 pt-4">
         <div className="flex justify-between items-center pb-4">
-          <GameListFilters searchParams={formattedSearchParams} />
+          <GameListFilters
+            searchParams={formattedSearchParams}
+            option={{
+              sorts: [
+                { value: "LATEST", optionLabel: "최신순" },
+                { value: "POPULAR", optionLabel: "인기순" },
+              ],
+            }}
+          />
         </div>
         <div className="h-[calc(100vh-12rem)] overflow-y-scroll">
           <GameList firstList={firstGameList} />

--- a/apps/game-builder/src/app/(my-page)/my-page/_components/ContinuedGame.tsx
+++ b/apps/game-builder/src/app/(my-page)/my-page/_components/ContinuedGame.tsx
@@ -8,7 +8,7 @@ export default async function ContinuedGame() {
     page: 1,
     limit: 8,
     genre: "ALL",
-    order: "LATEST",
+    sort: "LATEST",
   });
 
   return (

--- a/apps/game-builder/src/app/(my-page)/my-page/continued-game/page.tsx
+++ b/apps/game-builder/src/app/(my-page)/my-page/continued-game/page.tsx
@@ -16,8 +16,7 @@ export interface GameListParams {
 export default async function Page({ searchParams }: GameListParams) {
   const formattedSearchParams = formatGameListSearchParams(searchParams);
   const continuedGame = await getContinuedGame({
-    genre: formattedSearchParams.genre,
-    order: formattedSearchParams.sort,
+    ...formattedSearchParams,
     limit: 8,
     page: 1,
   });
@@ -26,7 +25,21 @@ export default async function Page({ searchParams }: GameListParams) {
     <div className="h-full flex flex-col">
       <TopNav title="진행 중인 게임" hasBackButton page="/my-page" />
       <div className="flex justify-between items-center mt-4 mb-5 px-5">
-        <GameListFilters searchParams={formattedSearchParams} />
+        <GameListFilters
+          searchParams={formattedSearchParams}
+          option={{
+            sorts: [
+              {
+                value: "LATEST",
+                optionLabel: "최신순",
+              },
+              {
+                value: "OLDEST",
+                optionLabel: "오래된 순",
+              },
+            ],
+          }}
+        />
       </div>
       <div className="flex-1 overflow-y-scroll pb-20 px-5">
         <ContinuedGameList continuedGame={continuedGame} />

--- a/apps/game-builder/src/interface/customType.ts
+++ b/apps/game-builder/src/interface/customType.ts
@@ -198,7 +198,7 @@ export interface GameListGame {
 
 export type GameList = GameListGame[];
 
-export type SortType = "POPULAR" | "LATEST";
+export type SortType = "POPULAR" | "LATEST" | "OLDEST";
 
 export interface User {
   id: number;
@@ -225,4 +225,8 @@ export interface ContinuedGamePlay extends Pick<Play, "id" | "page"> {
 export interface ContinuedGame {
   game: ContinuedGameGame;
   play: ContinuedGamePlay;
+}
+
+export interface GameListOption {
+  sorts: { value: SortType; optionLabel: string }[];
 }


### PR DESCRIPTION
## 기획 반영
- 페이지에 따라 필터 컴포넌트의 옵션이 다릅니다.
   - 게임 목록:"POPULAR" | "LATEST"
   - 진행 중인 게임: "LATEST" | "OLDEST" 
   - 내가 본 엔딩: "LATEST" | "OLDEST"
- option 형태에 따라 GameListFilters가 다르게 작동하도록 props 전달을 추가했습니다.

### GameListFilters 컴포넌트
![image](https://github.com/user-attachments/assets/10f2e896-8aa2-4f2f-9606-27f38c840bef)
```tsx
<GameListFilters
  searchParams={formattedSearchParams}
  option={{
    sorts: [
      { value: "LATEST", optionLabel: "최신순" },
      { value: "POPULAR", optionLabel: "인기순" },
    ],
  }}
/>
```

---

- 또한 sort와 order가 혼용되어 있는 점을 서버 액션에서 처리하도록 이동

