### PR TITLE
refactor(S8): 에러 핸들링 이미지 컴포넌트 개선 및 프로젝트 내 적용

### DIFF
--- a/apps/game-builder/src/app/(builder)/builder/list/@building/_components/GameBuilderCard.tsx
+++ b/apps/game-builder/src/app/(builder)/builder/list/@building/_components/GameBuilderCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import ErrorHandlingImage from "@/components/common/image/ImageWithError";
+import ImageWithError from "@/components/common/image/ImageWithError";
 import { useTranslation } from "@/hooks/useTranslation";
 import { formatDateString } from "@/utils/formatDatestring";
 import { type GameBuilderGame as GameBuilder } from "@/interface/customType";
@@ -26,7 +26,7 @@ export default function GameBuilderCard({ game }: GameBuilderCardProps) {
           <div className="flex gap-3">
             <div className="w-[3.75rem] shrink-0">
               <div className="relative w-full pb-[100%] rounded-md overflow-hidden bg-grey-200">
-                <ErrorHandlingImage src={game.thumbnail.url} alt={game.title} />
+                <ImageWithError src={game.thumbnail.url} alt={game.title} />
               </div>
             </div>
 

--- a/apps/game-builder/src/app/(builder)/builder/list/@published/_components/GameBuilderCard.tsx
+++ b/apps/game-builder/src/app/(builder)/builder/list/@published/_components/GameBuilderCard.tsx
@@ -1,6 +1,6 @@
 "use client";
 import Link from "next/link";
-import ErrorHandlingImage from "@/components/common/image/ImageWithError";
+import ImageWithError from "@/components/common/image/ImageWithError";
 import { useTranslation } from "@/hooks/useTranslation";
 import { formatDateString } from "@/utils/formatDatestring";
 import { type GameBuilderGame as GameBuilder } from "@/interface/customType";
@@ -30,7 +30,7 @@ export default function GameBuilderCard({ game }: GameBuilderCardProps) {
           <div className="flex gap-3">
             <div className="w-[3.75rem] shrink-0">
               <div className="relative w-full pb-[100%] rounded-md overflow-hidden bg-grey-200">
-                <ErrorHandlingImage src={game.thumbnail.url} alt={game.title} />
+                <ImageWithError src={game.thumbnail.url} alt={game.title} />
               </div>
             </div>
 

--- a/apps/game-builder/src/app/(game-list)/list/_components/game-intro-modal/GameIntroModal.tsx
+++ b/apps/game-builder/src/app/(game-list)/list/_components/game-intro-modal/GameIntroModal.tsx
@@ -14,7 +14,7 @@ import { AspectRatio } from "@/packages/ui/components/ui/AspectRatio";
 import { xIcon } from "@/asset/icons";
 import GameContinueButton from "@/app/(game-list)/list/_components/GameContinueButton";
 import GameStartButton from "@/app/(game-list)/list/_components/GameStartButton";
-import ErrorHandlingImage from "@/components/common/image/ImageWithError";
+import ImageWithError from "@/components/common/image/ImageWithError";
 import CompleteBadge from "../CompleteBadge";
 import PlayerImages from "../game-list-card/PlayerImages";
 import GameIntroBadge from "./GameIntroBadge";
@@ -82,7 +82,7 @@ export default function GameIntroModal({
     >
       <div className="absolute top-0 left-0 w-full">
         <AspectRatio ratio={9 / 9}>
-          <ErrorHandlingImage
+          <ImageWithError
             src={gameData.game.thumbnail?.url}
             alt="썸네일 이미지"
             sizes="(max-width: 600px) 80vw, 400px"

--- a/apps/game-builder/src/app/(game-list)/list/_components/game-intro-modal/GameIntroModal.tsx
+++ b/apps/game-builder/src/app/(game-list)/list/_components/game-intro-modal/GameIntroModal.tsx
@@ -1,4 +1,4 @@
-import { type SyntheticEvent, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 import Image from "next/image";
 import {
   DialogContent,
@@ -12,9 +12,9 @@ import { getGameIntro } from "@/actions/game-play/getIntro";
 import { useTranslation } from "@/hooks/useTranslation";
 import { AspectRatio } from "@/packages/ui/components/ui/AspectRatio";
 import { xIcon } from "@/asset/icons";
-import { getPlaceholderImageOnError } from "@/utils/getPlaceholderImageOnError";
 import GameContinueButton from "@/app/(game-list)/list/_components/GameContinueButton";
 import GameStartButton from "@/app/(game-list)/list/_components/GameStartButton";
+import ErrorHandlingImage from "@/components/common/image/ImageWithError";
 import CompleteBadge from "../CompleteBadge";
 import PlayerImages from "../game-list-card/PlayerImages";
 import GameIntroBadge from "./GameIntroBadge";
@@ -65,13 +65,6 @@ export default function GameIntroModal({
   const lastPageAbridgement = gameIntroData?.play?.page.abridgement;
   const gameDescription = gameIntroData?.game.description;
 
-  const [hasError, setHasError] = useState(false);
-  const handleImageError = (e: SyntheticEvent<HTMLImageElement>) => {
-    if (hasError) return;
-    setHasError(true);
-    getPlaceholderImageOnError(e);
-  };
-
   if (!gameData) return null;
   if (error) {
     return (
@@ -89,13 +82,10 @@ export default function GameIntroModal({
     >
       <div className="absolute top-0 left-0 w-full">
         <AspectRatio ratio={9 / 9}>
-          <Image
+          <ErrorHandlingImage
             src={gameData.game.thumbnail?.url}
             alt="썸네일 이미지"
-            fill
             sizes="(max-width: 600px) 80vw, 400px"
-            style={{ objectFit: "cover" }}
-            onError={handleImageError}
           />
           <div className="mt-[1px] absolute bg-gradient-to-b from-transparent from-50% to-80% to-grey-900 w-full h-full top-0 left-0" />
         </AspectRatio>

--- a/apps/game-builder/src/app/(game-list)/list/_components/game-list-card/GameListCard.tsx
+++ b/apps/game-builder/src/app/(game-list)/list/_components/game-list-card/GameListCard.tsx
@@ -1,7 +1,7 @@
 import { AspectRatio } from "@/packages/ui/components/ui/AspectRatio";
 import { type GameListGame } from "@/interface/customType";
 import { useTranslation } from "@/hooks/useTranslation";
-import ErrorHandlingImage from "@/components/common/image/ImageWithError";
+import ImageWithError from "@/components/common/image/ImageWithError";
 import CompleteBadge from "../CompleteBadge";
 import PlayerImages from "./PlayerImages";
 
@@ -22,7 +22,7 @@ export default function GameListCard({ gameData }: { gameData: GameListGame }) {
   return (
     <div>
       <AspectRatio ratio={1 / 1} className="mb-2">
-        <ErrorHandlingImage
+        <ImageWithError
           src={thumbnail?.url}
           alt="썸네일 이미지"
           sizes="(max-width: 600px) 80vw, 400px"

--- a/apps/game-builder/src/app/(game-list)/list/_components/game-list-card/GameListCard.tsx
+++ b/apps/game-builder/src/app/(game-list)/list/_components/game-list-card/GameListCard.tsx
@@ -1,19 +1,12 @@
-import { type SyntheticEvent, useState } from "react";
-import Image from "next/image";
-import { ImageIcon } from "@radix-ui/react-icons";
 import { AspectRatio } from "@/packages/ui/components/ui/AspectRatio";
 import { type GameListGame } from "@/interface/customType";
 import { useTranslation } from "@/hooks/useTranslation";
-import {
-  getPlaceholderImageOnError,
-  placeholderSrc,
-} from "@/utils/getPlaceholderImageOnError";
+import ErrorHandlingImage from "@/components/common/image/ImageWithError";
 import CompleteBadge from "../CompleteBadge";
 import PlayerImages from "./PlayerImages";
 
 export default function GameListCard({ gameData }: { gameData: GameListGame }) {
   const { t } = useTranslation();
-  const [isError, setIsError] = useState(false);
 
   const game = gameData.game;
   if (!game) return null;
@@ -22,11 +15,6 @@ export default function GameListCard({ gameData }: { gameData: GameListGame }) {
   const totalRechedEndingPlayCount =
     gameData.enrichData.totalRechedEndingPlayCount;
 
-  const handleError = (e: SyntheticEvent<HTMLImageElement>) => {
-    if (isError) return;
-    getPlaceholderImageOnError(e);
-    setIsError(true);
-  };
   const gamePlayerImageUrls = gameData.game.player
     .map((player) => player.profileImage.url)
     .filter((e) => e !== "");
@@ -34,21 +22,12 @@ export default function GameListCard({ gameData }: { gameData: GameListGame }) {
   return (
     <div>
       <AspectRatio ratio={1 / 1} className="mb-2">
-        <Image
-          src={thumbnail?.url ?? placeholderSrc}
-          alt={`thumbnail image ${thumbnail?.id}`}
-          className="rounded-md object-cover select-none"
-          onError={handleError}
-          fill
+        <ErrorHandlingImage
+          src={thumbnail?.url}
+          alt="썸네일 이미지"
           sizes="(max-width: 600px) 80vw, 400px"
-          style={{ objectFit: "cover" }}
+          hasErrorDisplay
         />
-        {(isError || !thumbnail?.url) && (
-          <div className="absolute w-full h-full rounded-md border border-red-500 flex justify-center items-center">
-            <ImageIcon className="w-10 h-10" color="#aaaaaa" />
-            <div className="w-[42px] border-b-2 absolute border-[#aaaaaa] -rotate-45" />
-          </div>
-        )}
         {gameData.enrichData.me.reachedEndingPlayCount > 0 && (
           <div className="absolute top-2 right-2 z-10">
             <CompleteBadge />

--- a/apps/game-builder/src/app/(game-list)/list/_components/game-list-card/PlayerImages.tsx
+++ b/apps/game-builder/src/app/(game-list)/list/_components/game-list-card/PlayerImages.tsx
@@ -1,33 +1,17 @@
-import { type SyntheticEvent, useState } from "react";
-import Image from "next/image";
-import { getPlaceholderImageOnError } from "@/utils/getPlaceholderImageOnError";
+import ErrorHandlingImage from "@/components/common/image/ImageWithError";
 
 export default function PlayerImages({
   gamePlayerImageUrls,
 }: {
   gamePlayerImageUrls: string[];
 }) {
-  const [hasError, setHasError] = useState(false);
-  const handleImageError = (e: SyntheticEvent<HTMLImageElement>) => {
-    if (hasError) return;
-    setHasError(true);
-    getPlaceholderImageOnError(e);
-  };
-
   return (
     <div>
       <ul className="flex mr-2">
         {gamePlayerImageUrls.slice(0, 3).map((src) => (
           <li key={src} className="w-2">
             <div className="relative bg-gray-200 w-4 h-4 rounded-full overflow-hidden">
-              <Image
-                src={src}
-                alt=""
-                fill
-                sizes="10px"
-                style={{ objectFit: "cover" }}
-                onError={handleImageError}
-              />
+              <ErrorHandlingImage src={src} alt="" sizes="10px" />
             </div>
           </li>
         ))}

--- a/apps/game-builder/src/app/(game-list)/list/_components/game-list-card/PlayerImages.tsx
+++ b/apps/game-builder/src/app/(game-list)/list/_components/game-list-card/PlayerImages.tsx
@@ -1,4 +1,4 @@
-import ErrorHandlingImage from "@/components/common/image/ImageWithError";
+import ImageWithError from "@/components/common/image/ImageWithError";
 
 export default function PlayerImages({
   gamePlayerImageUrls,
@@ -11,7 +11,7 @@ export default function PlayerImages({
         {gamePlayerImageUrls.slice(0, 3).map((src) => (
           <li key={src} className="w-2">
             <div className="relative bg-gray-200 w-4 h-4 rounded-full overflow-hidden">
-              <ErrorHandlingImage src={src} alt="" sizes="10px" />
+              <ImageWithError src={src} alt="" sizes="10px" />
             </div>
           </li>
         ))}

--- a/apps/game-builder/src/app/(my-page)/my-page/continued-game/_components/ContinuedGameCard.tsx
+++ b/apps/game-builder/src/app/(my-page)/my-page/continued-game/_components/ContinuedGameCard.tsx
@@ -3,7 +3,7 @@ import { useRouter } from "next/navigation";
 import { type ContinuedGame } from "@/interface/customType";
 import { formatDateString } from "@/utils/formatDatestring";
 import Button from "@/components/common/button/Button";
-import ErrorHandlingImage from "@components/common/image/ImageWithError";
+import ImageWithError from "@components/common/image/ImageWithError";
 
 interface ContinuedGameCardProps {
   continuedGame: ContinuedGame;
@@ -28,7 +28,7 @@ export default function ContinuedGameCard({
       className={`w-[calc(50%-1.125rem)] shrink-0 flex flex-col ${className}`}
     >
       <div className="relative w-full pb-[100%] rounded-md overflow-hidden bg-grey-200">
-        <ErrorHandlingImage
+        <ImageWithError
           src={continuedGame.game.thumbnail.url}
           alt={continuedGame.game.title}
         />

--- a/apps/game-builder/src/app/(my-page)/my-page/ended-game/@date/_components/GroupDateEndedGameCard.tsx
+++ b/apps/game-builder/src/app/(my-page)/my-page/ended-game/@date/_components/GroupDateEndedGameCard.tsx
@@ -3,7 +3,7 @@ import Link from "next/link";
 import { type EndedGameGroupDate } from "@/interface/customType";
 import { useTranslation } from "@/hooks/useTranslation";
 import { formatDateString } from "@/utils/formatDatestring";
-import ErrorHandlingImage from "@components/common/image/ImageWithError";
+import ImageWithError from "@components/common/image/ImageWithError";
 
 interface EndedGameCardProps {
   endedGame: EndedGameGroupDate;
@@ -21,7 +21,7 @@ export default function GroupDateEndedGameCard({
     >
       <div className="flex flex-col gap-2">
         <div className="relative w-full pb-[100%] rounded-md overflow-hidden bg-grey-200">
-          <ErrorHandlingImage
+          <ImageWithError
             src={endedGame.game.thumbnail.url}
             alt={endedGame.game.title}
           />

--- a/apps/game-builder/src/app/(my-page)/my-page/ended-game/@game/_components/GroupGameEndedGameCard.tsx
+++ b/apps/game-builder/src/app/(my-page)/my-page/ended-game/@game/_components/GroupGameEndedGameCard.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from "@/hooks/useTranslation";
 import { formatDateString } from "@/utils/formatDatestring";
 import { type EndedGameGroupGame } from "@/interface/customType";
 import ChevronDownIcon from "@asset/icons/chevron-down.svg";
-import ErrorHandlingImage from "@/components/common/image/ImageWithError";
+import ImageWithError from "@/components/common/image/ImageWithError";
 
 interface EndedGameCardProps {
   endedGame: EndedGameGroupGame;
@@ -36,7 +36,7 @@ export default function GroupGameEndedGameCard({
             </p>
           </div>
           <div className="relative w-full pb-[100%] rounded-md overflow-hidden bg-grey-200">
-            <ErrorHandlingImage
+            <ImageWithError
               src={endedGame.game.thumbnail?.url}
               alt={endedGame.game.title}
             />

--- a/apps/game-builder/src/app/(oauth)/oauth/page.tsx
+++ b/apps/game-builder/src/app/(oauth)/oauth/page.tsx
@@ -1,20 +1,12 @@
-import Image from "next/image";
 import { placeholderSrc } from "@/utils/getPlaceholderImageOnError";
+import ErrorHandlingImage from "@/components/common/image/ImageWithError";
 import SocialLogin from "./_components/SocialLogin";
 
 export default function Page() {
   return (
     <div className="h-full flex flex-col items-center justify-center">
       <div className="relative flex-1 w-full">
-        <Image
-          src={placeholderSrc}
-          alt="ChooseTale"
-          className="object-cover border select-none"
-          fill
-          priority
-          sizes="(max-width: 600px) 80vw, 400px"
-          style={{ objectFit: "cover" }}
-        />
+        <ErrorHandlingImage src={placeholderSrc} alt="ChooseTale" />
       </div>
       <SocialLogin />
     </div>

--- a/apps/game-builder/src/app/(oauth)/oauth/page.tsx
+++ b/apps/game-builder/src/app/(oauth)/oauth/page.tsx
@@ -1,12 +1,12 @@
 import { placeholderSrc } from "@/utils/getPlaceholderImageOnError";
-import ErrorHandlingImage from "@/components/common/image/ImageWithError";
+import ImageWithError from "@/components/common/image/ImageWithError";
 import SocialLogin from "./_components/SocialLogin";
 
 export default function Page() {
   return (
     <div className="h-full flex flex-col items-center justify-center">
       <div className="relative flex-1 w-full">
-        <ErrorHandlingImage src={placeholderSrc} alt="ChooseTale" />
+        <ImageWithError src={placeholderSrc} alt="ChooseTale" />
       </div>
       <SocialLogin />
     </div>

--- a/apps/game-builder/src/components/common/image/ImageWithError.tsx
+++ b/apps/game-builder/src/components/common/image/ImageWithError.tsx
@@ -1,16 +1,25 @@
 "use client";
 import { type SyntheticEvent, useState, useMemo } from "react";
-import Image from "next/image";
+import Image, { type ImageProps } from "next/image";
+import { ImageIcon } from "@radix-ui/react-icons";
 import { getPlaceholderImageOnError } from "@/utils/getPlaceholderImageOnError";
+
+interface ErrorHandlingImageProps extends Omit<ImageProps, "src"> {
+  src: string | null;
+  hasErrorDisplay?: boolean;
+}
 
 export default function ErrorHandlingImage({
   src,
   alt,
-}: {
-  src: string;
-  alt: string;
-}) {
+  sizes = "(max-width: 600px) 80vw, 400px",
+  hasErrorDisplay = false,
+}: ErrorHandlingImageProps) {
   const [hasError, setHasError] = useState(false);
+  let currentSrc = "";
+  if (src && !src.includes("undefined")) {
+    currentSrc = src;
+  }
 
   const handleImageError = useMemo(() => {
     return (e: SyntheticEvent<HTMLImageElement>) => {
@@ -23,15 +32,25 @@ export default function ErrorHandlingImage({
   const MemoizedImage = useMemo(() => {
     return (
       <Image
-        src={src}
+        src={currentSrc}
         alt={alt}
         fill
-        sizes="(max-width: 600px) 80vw, 400px"
+        sizes={sizes}
         style={{ objectFit: "cover" }}
         onError={handleImageError}
       />
     );
-  }, [src, alt, handleImageError]);
+  }, [currentSrc, alt, sizes, handleImageError]);
 
-  return <div className="w-full h-full">{MemoizedImage}</div>;
+  return (
+    <div className="w-full h-full">
+      {MemoizedImage}
+      {(hasError || !currentSrc) && hasErrorDisplay && (
+        <div className="absolute w-full h-full rounded-md border border-red-500 flex justify-center items-center z-10">
+          <ImageIcon className="w-10 h-10" color="#aaaaaa" />
+          <div className="w-[42px] border-b-2 absolute border-[#aaaaaa] -rotate-45" />
+        </div>
+      )}
+    </div>
+  );
 }

--- a/apps/game-builder/src/components/common/image/ImageWithError.tsx
+++ b/apps/game-builder/src/components/common/image/ImageWithError.tsx
@@ -9,7 +9,7 @@ interface ErrorHandlingImageProps extends Omit<ImageProps, "src"> {
   hasErrorDisplay?: boolean;
 }
 
-export default function ErrorHandlingImage({
+export default function ImageWithError({
   src,
   alt,
   sizes = "(max-width: 600px) 80vw, 400px",

--- a/apps/game-builder/src/components/theme/ui/ThemedCarousel.tsx
+++ b/apps/game-builder/src/components/theme/ui/ThemedCarousel.tsx
@@ -11,7 +11,7 @@ import {
 import { AspectRatio } from "@repo/ui/components/ui/AspectRatio.tsx";
 import { useThemeStore } from "@/store/useTheme";
 import { type Thumbnail } from "@/interface/customType";
-import ErrorHandlingImage from "@/components/common/image/ImageWithError";
+import ImageWithError from "@/components/common/image/ImageWithError";
 
 interface ThemedCarouselProps {
   thumbnails: Thumbnail[];
@@ -113,7 +113,7 @@ function CarouselItemWithOnError({
     <CarouselItem className="px-2">
       <AspectRatio ratio={9 / 9}>
         <div className="absolute w-full h-full">
-          <ErrorHandlingImage
+          <ImageWithError
             src={thumbnail?.url}
             alt={`썸네일 이미지 ${thumbnail.id}`}
             priority={idx <= 1}

--- a/apps/game-builder/src/components/theme/ui/ThemedCarousel.tsx
+++ b/apps/game-builder/src/components/theme/ui/ThemedCarousel.tsx
@@ -1,12 +1,5 @@
-import {
-  type Dispatch,
-  type SetStateAction,
-  type SyntheticEvent,
-  useEffect,
-  useState,
-} from "react";
-import Image from "next/image";
-import { ImageIcon, StarFilledIcon } from "@radix-ui/react-icons";
+import { type Dispatch, type SetStateAction, useEffect, useState } from "react";
+import { StarFilledIcon } from "@radix-ui/react-icons";
 import {
   Carousel,
   CarouselContent,
@@ -18,10 +11,7 @@ import {
 import { AspectRatio } from "@repo/ui/components/ui/AspectRatio.tsx";
 import { useThemeStore } from "@/store/useTheme";
 import { type Thumbnail } from "@/interface/customType";
-import {
-  getPlaceholderImageOnError,
-  placeholderSrc,
-} from "@/utils/getPlaceholderImageOnError";
+import ErrorHandlingImage from "@/components/common/image/ImageWithError";
 
 interface ThemedCarouselProps {
   thumbnails: Thumbnail[];
@@ -119,35 +109,17 @@ function CarouselItemWithOnError({
   isMainThumbnailImageId: boolean;
   onChangeMainThumbnailImageId: (id: number) => void;
 }) {
-  const [isError, setIsError] = useState(false);
-
-  const handleError = (e: SyntheticEvent<HTMLImageElement>) => {
-    if (isError) return;
-    getPlaceholderImageOnError(e);
-    setIsError(true);
-  };
-
   return (
     <CarouselItem className="px-2">
       <AspectRatio ratio={9 / 9}>
         <div className="absolute w-full h-full">
-          <Image
-            src={thumbnail?.url ?? placeholderSrc}
-            alt={`thumbnail image ${thumbnail.id}`}
-            className="rounded-md object-cover border select-none"
-            onError={handleError}
-            fill
+          <ErrorHandlingImage
+            src={thumbnail?.url}
+            alt={`썸네일 이미지 ${thumbnail.id}`}
             priority={idx <= 1}
-            sizes="(max-width: 600px) 80vw, 400px"
-            style={{ objectFit: "cover" }}
+            hasErrorDisplay
           />
         </div>
-        {(isError || !thumbnail?.url) && (
-          <div className="absolute w-full h-full rounded-md border border-red-500 flex justify-center items-center">
-            <ImageIcon className="w-10 h-10" color="#aaaaaa" />
-            <div className="w-[42px] border-b-2 absolute border-[#aaaaaa] -rotate-45" />
-          </div>
-        )}
         <div className="absolute right-0 p-3">
           <button
             onClick={() => onChangeMainThumbnailImageId(thumbnail.id)}


### PR DESCRIPTION
## 작업 내용

- ErrorHandlingImage에 전달되는 url이 null이거나, 잘못된 형태(url내에 undefined를 포함하고 있는 string)인 경우의 로직을 추가했습니다.
- 프로젝트 내에 공통적으로 적용하고, hasErrorDisplay key를 추가했습니다.

## `ErrorHandlingImage` 
- 이미지 로딩 오류를 처리하고 대체 이미지를 표시
- Next.js의 `Image` 컴포넌트를 확장

```tsx
<ImageWithError
  src={thumbnail?.url}
  alt="썸네일 이미지"
  sizes="(max-width: 600px) 80vw, 400px"
  hasErrorDisplay
/>
```

### 동작

1. `src`가 유효한지 확인
2. 이미지 로딩 오류 발생 시 `handleImageError` 함수 실행
3. 오류가 발생했거나 `src`가 없는 경우에, `hasErrorDisplay`가 `true`라면 시각적 오류를 표시 렌더링 (시각적 오류 표시: 아이콘과 빨간색 테두리)